### PR TITLE
 fix: correct typo 'histroy_agent' → 'history_agent'

### DIFF
--- a/examples/routing/main.go
+++ b/examples/routing/main.go
@@ -86,11 +86,11 @@ func main() {
 	var (
 		routes = map[string]string{
 			"math_agent":    "You provide help with math problems. Explain your reasoning at each step and include examples.",
-			"histroy_agent": "You provide assistance with historical queries. Explain important events and context clearly.",
+			"history_agent": "You provide assistance with historical queries. Explain important events and context clearly.",
 		}
 	)
 	routing := NewRoutingWorkflow(routes)
-	// Example prompt that will be routed to the histroy_agent
+	// Example prompt that will be routed to the history_agent
 	prompt := blades.NewPrompt(
 		blades.UserMessage("What is the capital of France?"),
 	)


### PR DESCRIPTION
## What
Fixed a spelling mistake in the routes map: changed "histroy_agent" to "history_agent".

## Why
The misspelling could cause confusion or lead to lookup failures if someone tries to use "history_agent". Using the correct spelling ensures consistency and avoids potential issues.

## Impact / Compatibility

If other parts of the project still reference "histroy_agent", they will no longer find a match after this change.
To maintain backward compatibility, we could temporarily keep "histroy_agent" as an alias while introducing "history_agent", then gradually migrate references.

## How to test

Run go test ./... to ensure all unit tests pass.
Verify that lookups using "history_agent" return the expected value.