### PR TITLE
perf(output-converter): cache JSON schema to reduce runtime overhead

### DIFF
--- a/examples/routing/main.go
+++ b/examples/routing/main.go
@@ -86,11 +86,11 @@ func main() {
 	var (
 		routes = map[string]string{
 			"math_agent":    "You provide help with math problems. Explain your reasoning at each step and include examples.",
-			"histroy_agent": "You provide assistance with historical queries. Explain important events and context clearly.",
+			"history_agent": "You provide assistance with historical queries. Explain important events and context clearly.",
 		}
 	)
 	routing := NewRoutingWorkflow(routes)
-	// Example prompt that will be routed to the histroy_agent
+	// Example prompt that will be routed to the history_agent
 	prompt := blades.NewPrompt(
 		blades.UserMessage("What is the capital of France?"),
 	)


### PR DESCRIPTION
### Summary
This PR introduces a caching mechanism for JSON schemas in OutputConverter to improve performance.  
Previously, JSON schema reflection was performed on every Run call, which can be expensive. Now, the schema is generated once during construction and reused.

### Changes
- Added a `schema string` field to OutputConverter
- Generate and store schema in `NewOutputConverter`
- Use cached schema in `Run`

### Benefits
- Reduced repeated computation
- Better performance in repeated Run calls
- Maintains thread safety without additional locks

### Testing
- Verified existing unit tests
- Local benchmarks show reduced latency for repeated runs
