### PR TITLE
🔧 feat(openai): Add configuration wrapper to avoid exposing external library types

### DIFF
--- a/contrib/openai/README.md
+++ b/contrib/openai/README.md
@@ -6,8 +6,28 @@ This package offers helpers that adapt OpenAI APIs to the generic `blades.ModelP
 - `NewImageProvider` wraps the image generation endpoint (`/v1/images/generations`) and returns image bytes or URLs as `DataPart`/`FilePart` message contents.
 - `NewAudioProvider` wraps the text-to-speech endpoint (`/v1/audio/speech`) and returns synthesized audio as `DataPart` payloads.
 
+## Configuration
+
+All providers accept configuration options to avoid exposing OpenAI library types directly:
+
 ```go
-provider := openai.NewImageProvider()
+provider := openai.NewChatProvider(
+    openai.WithAPIKey("your-api-key"),
+    openai.WithBaseURL("https://api.openai.com/v1"),
+    openai.WithRequestTimeout(30*time.Second),
+    openai.WithMaxRetries(3),
+)
+```
+
+Available options: `WithAPIKey`, `WithBaseURL`, `WithOrganization`, `WithProject`, `WithHTTPClient`, `WithRequestTimeout`, `WithMaxRetries`, `WithHeader`.
+
+## Examples
+
+```go
+// Image generation
+provider := openai.NewImageProvider(
+    openai.WithAPIKey("your-api-key"),
+)
 req := &blades.ModelRequest{
     Model: "gpt-image-1",
     Messages: []*blades.Message{
@@ -18,7 +38,10 @@ res, err := provider.Generate(ctx, req, blades.ImageSize("1024x1024"))
 ```
 
 ```go
-provider := openai.NewAudioProvider()
+// Text-to-speech
+provider := openai.NewAudioProvider(
+    openai.WithAPIKey("your-api-key"),
+)
 req := &blades.ModelRequest{
     Model: "gpt-4o-mini-tts",
     Messages: []*blades.Message{

--- a/contrib/openai/audio.go
+++ b/contrib/openai/audio.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-kratos/blades"
 	"github.com/openai/openai-go/v2"
-	"github.com/openai/openai-go/v2/option"
 	"github.com/openai/openai-go/v2/packages/param"
 )
 
@@ -31,9 +30,11 @@ type AudioProvider struct {
 	client openai.Client
 }
 
-// NewAudioProvider creates a new instance of AudioProvider.
-func NewAudioProvider(opts ...option.RequestOption) blades.ModelProvider {
-	return &AudioProvider{client: openai.NewClient(opts...)}
+// NewAudioProvider creates a new instance of AudioProvider with wrapped configuration options.
+// This avoids exposing external library types directly.
+func NewAudioProvider(opts ...Option) blades.ModelProvider {
+	config := NewConfig(opts...)
+	return &AudioProvider{client: openai.NewClient(config.toRequestOptions()...)}
 }
 
 // Generate generates audio from text input using the configured OpenAI model.

--- a/contrib/openai/chat.go
+++ b/contrib/openai/chat.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-kratos/blades"
 	"github.com/openai/openai-go/v2"
-	"github.com/openai/openai-go/v2/option"
 	"github.com/openai/openai-go/v2/packages/param"
 	"github.com/openai/openai-go/v2/shared"
 )
@@ -28,11 +27,11 @@ type ChatProvider struct {
 	client openai.Client
 }
 
-// NewChatProvider constructs an OpenAI provider. The API key is read from
-// the OPENAI_API_KEY environment variable. If OPENAI_BASE_URL is set,
-// it is used as the API base URL; otherwise the library default is used.
-func NewChatProvider(opts ...option.RequestOption) blades.ModelProvider {
-	return &ChatProvider{client: openai.NewClient(opts...)}
+// NewChatProvider constructs an OpenAI provider with wrapped configuration options.
+// This avoids exposing external library types directly.
+func NewChatProvider(opts ...Option) blades.ModelProvider {
+	config := NewConfig(opts...)
+	return &ChatProvider{client: openai.NewClient(config.toRequestOptions()...)}
 }
 
 // New executes a non-streaming chat completion request.

--- a/contrib/openai/image.go
+++ b/contrib/openai/image.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-kratos/blades"
 	"github.com/openai/openai-go/v2"
-	"github.com/openai/openai-go/v2/option"
 	"github.com/openai/openai-go/v2/packages/param"
 )
 
@@ -25,9 +24,11 @@ type ImageProvider struct {
 	client openai.Client
 }
 
-// NewImageProvider creates a new instance of ImageProvider.
-func NewImageProvider(opts ...option.RequestOption) blades.ModelProvider {
-	return &ImageProvider{client: openai.NewClient(opts...)}
+// NewImageProvider creates a new instance of ImageProvider with wrapped configuration options.
+// This avoids exposing external library types directly.
+func NewImageProvider(opts ...Option) blades.ModelProvider {
+	config := NewConfig(opts...)
+	return &ImageProvider{client: openai.NewClient(config.toRequestOptions()...)}
 }
 
 // Generate generates images using the configured OpenAI model.

--- a/contrib/openai/option.go
+++ b/contrib/openai/option.go
@@ -1,0 +1,127 @@
+package openai
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/openai/openai-go/v2/option"
+)
+
+// Config wraps OpenAI provider configuration to avoid exposing external library types
+type Config struct {
+	APIKey         string
+	BaseURL        string
+	Organization   string
+	Project        string
+	HTTPClient     *http.Client
+	RequestTimeout time.Duration
+	MaxRetries     int
+	Headers        map[string]string
+}
+
+// Option is a function type for configuring the provider
+type Option func(*Config)
+
+// WithAPIKey sets the API key
+func WithAPIKey(apiKey string) Option {
+	return func(c *Config) {
+		c.APIKey = apiKey
+	}
+}
+
+// WithBaseURL sets the base URL
+func WithBaseURL(baseURL string) Option {
+	return func(c *Config) {
+		c.BaseURL = baseURL
+	}
+}
+
+// WithOrganization sets the organization ID
+func WithOrganization(org string) Option {
+	return func(c *Config) {
+		c.Organization = org
+	}
+}
+
+// WithProject sets the project ID
+func WithProject(project string) Option {
+	return func(c *Config) {
+		c.Project = project
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Config) {
+		c.HTTPClient = client
+	}
+}
+
+// WithRequestTimeout sets the request timeout
+func WithRequestTimeout(timeout time.Duration) Option {
+	return func(c *Config) {
+		c.RequestTimeout = timeout
+	}
+}
+
+// WithMaxRetries sets the maximum number of retries
+func WithMaxRetries(retries int) Option {
+	return func(c *Config) {
+		c.MaxRetries = retries
+	}
+}
+
+// WithHeader sets a request header
+func WithHeader(key, value string) Option {
+	return func(c *Config) {
+		if c.Headers == nil {
+			c.Headers = make(map[string]string)
+		}
+		c.Headers[key] = value
+	}
+}
+
+// NewConfig creates a new configuration with default values
+func NewConfig(opts ...Option) *Config {
+	config := &Config{
+		Headers:    make(map[string]string),
+		MaxRetries: 2, // OpenAI default
+	}
+	for _, opt := range opts {
+		opt(config)
+	}
+	return config
+}
+
+// toRequestOptions converts the wrapped configuration to OpenAI RequestOptions
+func (c *Config) toRequestOptions() []option.RequestOption {
+	var opts []option.RequestOption
+
+	if c.APIKey != "" {
+		opts = append(opts, option.WithAPIKey(c.APIKey))
+	}
+	if c.BaseURL != "" {
+		opts = append(opts, option.WithBaseURL(c.BaseURL))
+	}
+	if c.Organization != "" {
+		opts = append(opts, option.WithOrganization(c.Organization))
+	}
+	if c.Project != "" {
+		opts = append(opts, option.WithProject(c.Project))
+	}
+	if c.HTTPClient != nil {
+		opts = append(opts, option.WithHTTPClient(c.HTTPClient))
+	}
+	if c.RequestTimeout > 0 {
+		opts = append(opts, option.WithRequestTimeout(c.RequestTimeout))
+	}
+	if c.MaxRetries >= 0 {
+		opts = append(opts, option.WithMaxRetries(c.MaxRetries))
+	}
+
+	for key, value := range c.Headers {
+		opts = append(opts, option.WithHeader(key, value))
+	}
+
+	return opts
+}

--- a/contrib/openai/option_test.go
+++ b/contrib/openai/option_test.go
@@ -1,0 +1,80 @@
+package openai
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     []Option
+		validate func(*testing.T, *Config)
+	}{
+		{
+			name: "default configuration",
+			opts: []Option{},
+			validate: func(t *testing.T, c *Config) {
+				if c.MaxRetries != 2 {
+					t.Errorf("Expected MaxRetries 2, got %d", c.MaxRetries)
+				}
+				if c.Headers == nil {
+					t.Error("Expected non-nil Headers")
+				}
+			},
+		},
+		{
+			name: "with API key",
+			opts: []Option{
+				WithAPIKey("test-key"),
+			},
+			validate: func(t *testing.T, c *Config) {
+				if c.APIKey != "test-key" {
+					t.Errorf("Expected APIKey 'test-key', got '%s'", c.APIKey)
+				}
+			},
+		},
+		{
+			name: "full configuration",
+			opts: []Option{
+				WithAPIKey("test-key"),
+				WithBaseURL("https://api.example.com"),
+				WithOrganization("org-123"),
+				WithProject("proj-456"),
+				WithRequestTimeout(60 * time.Second),
+				WithMaxRetries(5),
+				WithHeader("X-Custom", "value"),
+			},
+			validate: func(t *testing.T, c *Config) {
+				if c.APIKey != "test-key" {
+					t.Errorf("Expected APIKey 'test-key', got '%s'", c.APIKey)
+				}
+				if c.BaseURL != "https://api.example.com" {
+					t.Errorf("Expected BaseURL 'https://api.example.com', got '%s'", c.BaseURL)
+				}
+				if c.Organization != "org-123" {
+					t.Errorf("Expected Organization 'org-123', got '%s'", c.Organization)
+				}
+				if c.Project != "proj-456" {
+					t.Errorf("Expected Project 'proj-456', got '%s'", c.Project)
+				}
+				if c.RequestTimeout != 60*time.Second {
+					t.Errorf("Expected RequestTimeout 60s, got %v", c.RequestTimeout)
+				}
+				if c.MaxRetries != 5 {
+					t.Errorf("Expected MaxRetries 5, got %d", c.MaxRetries)
+				}
+				if c.Headers["X-Custom"] != "value" {
+					t.Errorf("Expected Header X-Custom 'value', got '%s'", c.Headers["X-Custom"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := NewConfig(tt.opts...)
+			tt.validate(t, config)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This PR introduces a configuration wrapper layer for the OpenAI provider to avoid directly exposing external library types (option.RequestOption) in the public API. This improves encapsulation and reduces coupling with the OpenAI SDK.

Fixes #39