### PR TITLE
refactor: remove unnecessary i := i in range loop

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -247,7 +247,6 @@ func (a *Agent) executeTools(ctx context.Context, message *Message) (*Message, e
 	toolMessage := &Message{ID: message.ID, Role: message.Role, Parts: message.Parts}
 	eg, ctx := errgroup.WithContext(ctx)
 	for i, part := range message.Parts {
-		i := i
 		switch v := any(part).(type) {
 		case ToolPart:
 			eg.Go(func() error {


### PR DESCRIPTION
- Remove i := i pattern in executeTools function
- Go 1.22+ automatically creates new variables for each iteration
- Reference: https://go.dev/doc/go1.22#language