### PR TITLE
feat(stream): add early termination support and error handling in Observe.

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -242,7 +242,9 @@ func (a *Agent) RunStream(ctx context.Context, prompt *Prompt, opts ...ModelOpti
 		}
 		handler := a.handler(invocation, req)
 		for m, err := range handler.RunStream(ctx, prompt, opts...) {
-			yield(m, err)
+			if !yield(m, err) {
+				break
+			}
 		}
 	}
 }
@@ -376,7 +378,9 @@ func (a *Agent) handler(invocation *InvocationContext, req *ModelRequest) Runnab
 						if res.Message.Status == StatusCompleted {
 							finalResponse = res
 						} else {
-							yield(res.Message, nil)
+							if !yield(res.Message, nil) {
+								return // early termination
+							}
 						}
 					}
 					if finalResponse == nil {

--- a/examples/middleware/guardrails.go
+++ b/examples/middleware/guardrails.go
@@ -29,7 +29,11 @@ func (m *Guardrails) Run(ctx context.Context, prompt *blades.Prompt, opts ...bla
 func (m *Guardrails) RunStream(ctx context.Context, prompt *blades.Prompt, opts ...blades.ModelOption) stream.Streamable[*blades.Message] {
 	// Pre-processing: Add guardrails to the prompt
 	log.Println("Applying guardrails to the prompt (streaming)")
-	return stream.Observe(m.next.RunStream(ctx, prompt, opts...), func(msg *blades.Message) error {
+	return stream.Observe(m.next.RunStream(ctx, prompt, opts...), func(msg *blades.Message, err error) error {
+		if err != nil {
+			log.Println("Error during streaming:", err)
+			return err
+		}
 		log.Println("Streaming with guardrails applied:", msg.Text())
 		return nil
 	})

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -39,16 +39,13 @@ func Filter[T any](stream Streamable[T], predicate func(T) bool) Streamable[T] {
 // observer function to each value from the input channel. The observer function
 // is called for each value and returns an error; if a non-nil error is returned,
 // observation stops and the error is emitted.
-func Observe[T any](stream Streamable[T], observer func(T) error) Streamable[T] {
+func Observe[T any](stream Streamable[T], observer func(T, error) error) Streamable[T] {
 	return func(yield func(T, error) bool) {
 		stream(func(v T, err error) bool {
-			if err != nil {
-				return yield(*new(T), err)
+			if err := observer(v, err); err != nil {
+				return yield(v, err)
 			}
-			if err := observer(v); err != nil {
-				return yield(*new(T), err)
-			}
-			return yield(v, nil)
+			return yield(v, err)
 		})
 	}
 }


### PR DESCRIPTION
Stream observe usage:
```
stream.Observe(m.next.RunStream(ctx, prompt, opts...), func(msg *blades.Message, err error) error {
	if err != nil {
		log.Println("Error during streaming:", err)
		return err
	}
	log.Println("Streaming with guardrails applied:", msg.Text())
	return nil
}
```