### PR TITLE
fix(agent): Fix goroutine closure capturing loop variable issue in executeTools

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -296,6 +296,7 @@ func (a *agent) executeTools(ctx context.Context, message *Message) (*Message, e
 	for i, part := range message.Parts {
 		switch v := any(part).(type) {
 		case ToolPart:
+			i, v := i, v
 			eg.Go(func() error {
 				part, err := a.handleTools(ctx, v)
 				if err != nil {


### PR DESCRIPTION
在 executeTools 中，goroutine 闭包直接使用了 range 循环变量，可能导致索引和值错乱
修复：在启动 goroutine 前使用 i, v := i, v 重新绑定循环变量