### PR TITLE
feat(flow): allow to add middlewares as an option to DeepAgent and RoutingAgent

### DIFF
--- a/flow/deep.go
+++ b/flow/deep.go
@@ -18,6 +18,7 @@ type DeepConfig struct {
 	SubAgents                  []blades.Agent
 	MaxIterations              int
 	WithoutGeneralPurposeAgent bool
+	Middlewares                []blades.Middleware
 }
 
 // NewDeepAgent constructs and returns a "deep agent" using the provided configuration.
@@ -55,5 +56,6 @@ func NewDeepAgent(config DeepConfig) (blades.Agent, error) {
 		blades.WithInstruction(strings.Join(tc.Instructions, "\n\n")),
 		blades.WithTools(tc.Tools...),
 		blades.WithMaxIterations(config.MaxIterations),
+		blades.WithMiddleware(config.Middlewares...),
 	)
 }

--- a/flow/routing.go
+++ b/flow/routing.go
@@ -14,6 +14,7 @@ type RoutingConfig struct {
 	Description string
 	Model       blades.ModelProvider
 	SubAgents   []blades.Agent
+	Middlewares []blades.Middleware
 }
 
 type RoutingAgent struct {
@@ -32,6 +33,7 @@ func NewRoutingAgent(config RoutingConfig) (blades.Agent, error) {
 		blades.WithDescription(config.Description),
 		blades.WithInstruction(instruction),
 		blades.WithTools(handoff.NewHandoffTool()),
+		blades.WithMiddleware(config.Middlewares...),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Given that middleware is widely used in real world, this PR adds an option to enable it for DeepAgent and RoutingAgent.