### PR TITLE
fix(contrib): repair anthropic tool call flow

### DIFF
--- a/contrib/anthropic/claude_test.go
+++ b/contrib/anthropic/claude_test.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/go-kratos/blades"
@@ -27,5 +28,104 @@ func TestToClaudeParamsAssistantRole(t *testing.T) {
 	}
 	if got, want := string(params.Messages[1].Role), "assistant"; got != want {
 		t.Fatalf("second role = %q, want %q", got, want)
+	}
+}
+
+func TestToClaudeParamsToolRole(t *testing.T) {
+	t.Parallel()
+
+	model := &Claude{model: "claude-test"}
+	params, err := model.toClaudeParams(&blades.ModelRequest{
+		Messages: []*blades.Message{
+			{
+				Role: blades.RoleTool,
+				Parts: []blades.Part{
+					blades.TextPart{Text: "Let me check that."},
+					blades.ToolPart{
+						ID:       "toolu_123",
+						Name:     "get_weather",
+						Request:  `{"city":"Paris","unit":"C"}`,
+						Response: `{"temperature":21}`,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("toClaudeParams returned error: %v", err)
+	}
+
+	payload, err := json.Marshal(params.Messages)
+	if err != nil {
+		t.Fatalf("marshal params messages: %v", err)
+	}
+	var messages []map[string]any
+	if err := json.Unmarshal(payload, &messages); err != nil {
+		t.Fatalf("unmarshal params messages payload: %v", err)
+	}
+
+	if got, want := len(messages), 2; got != want {
+		t.Fatalf("messages len = %d, want %d", got, want)
+	}
+	if got, want := messages[0]["role"], "assistant"; got != want {
+		t.Fatalf("first role = %v, want %v", got, want)
+	}
+	if got, want := messages[1]["role"], "user"; got != want {
+		t.Fatalf("second role = %v, want %v", got, want)
+	}
+
+	assistantContent, ok := messages[0]["content"].([]any)
+	if !ok || len(assistantContent) != 2 {
+		t.Fatalf("first message content malformed: %v", messages[0]["content"])
+	}
+	textBlock, ok := assistantContent[0].(map[string]any)
+	if !ok || textBlock["type"] != "text" || textBlock["text"] != "Let me check that." {
+		t.Fatalf("assistant text block malformed: %v", assistantContent[0])
+	}
+	toolUseBlock, ok := assistantContent[1].(map[string]any)
+	if !ok {
+		t.Fatalf("assistant tool_use block malformed: %v", assistantContent[1])
+	}
+	if got, want := toolUseBlock["type"], "tool_use"; got != want {
+		t.Fatalf("tool_use block type = %v, want %v", got, want)
+	}
+	if got, want := toolUseBlock["id"], "toolu_123"; got != want {
+		t.Fatalf("tool_use id = %v, want %v", got, want)
+	}
+	if got, want := toolUseBlock["name"], "get_weather"; got != want {
+		t.Fatalf("tool_use name = %v, want %v", got, want)
+	}
+	input, ok := toolUseBlock["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool_use input malformed: %v", toolUseBlock["input"])
+	}
+	if got, want := input["city"], "Paris"; got != want {
+		t.Fatalf("tool_use input.city = %v, want %v", got, want)
+	}
+	if got, want := input["unit"], "C"; got != want {
+		t.Fatalf("tool_use input.unit = %v, want %v", got, want)
+	}
+
+	userContent, ok := messages[1]["content"].([]any)
+	if !ok || len(userContent) != 1 {
+		t.Fatalf("second message content malformed: %v", messages[1]["content"])
+	}
+	toolResultBlock, ok := userContent[0].(map[string]any)
+	if !ok {
+		t.Fatalf("tool_result block malformed: %v", userContent[0])
+	}
+	if got, want := toolResultBlock["type"], "tool_result"; got != want {
+		t.Fatalf("tool_result block type = %v, want %v", got, want)
+	}
+	if got, want := toolResultBlock["tool_use_id"], "toolu_123"; got != want {
+		t.Fatalf("tool_result tool_use_id = %v, want %v", got, want)
+	}
+	resultContent, ok := toolResultBlock["content"].([]any)
+	if !ok || len(resultContent) != 1 {
+		t.Fatalf("tool_result content malformed: %v", toolResultBlock["content"])
+	}
+	resultTextBlock, ok := resultContent[0].(map[string]any)
+	if !ok || resultTextBlock["type"] != "text" || resultTextBlock["text"] != `{"temperature":21}` {
+		t.Fatalf("tool_result text block malformed: %v", resultContent[0])
 	}
 }

--- a/contrib/anthropic/types_test.go
+++ b/contrib/anthropic/types_test.go
@@ -1,0 +1,125 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	anthropicSDK "github.com/anthropics/anthropic-sdk-go"
+	"github.com/go-kratos/blades"
+)
+
+func TestConvertClaudeToBladesToolUseRole(t *testing.T) {
+	t.Parallel()
+
+	message := decodeAnthropicMessage(t, `{
+		"id": "msg_1",
+		"content": [
+			{"type":"tool_use","id":"toolu_1","name":"get_weather","input":{"city":"Paris"}}
+		],
+		"model": "claude-sonnet-4-20250514",
+		"role": "assistant",
+		"stop_reason": "tool_use",
+		"stop_sequence": "",
+		"type": "message",
+		"usage": {
+			"cache_creation": {"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},
+			"cache_creation_input_tokens": 0,
+			"cache_read_input_tokens": 0,
+			"input_tokens": 1,
+			"output_tokens": 1,
+			"server_tool_use": {"web_search_requests":0},
+			"service_tier": "standard"
+		}
+	}`)
+
+	response, err := convertClaudeToBlades(message, blades.StatusCompleted)
+	if err != nil {
+		t.Fatalf("convertClaudeToBlades returned error: %v", err)
+	}
+	if got, want := response.Message.Role, blades.RoleTool; got != want {
+		t.Fatalf("message role = %q, want %q", got, want)
+	}
+	if got, want := len(response.Message.Parts), 1; got != want {
+		t.Fatalf("parts len = %d, want %d", got, want)
+	}
+
+	toolPart, ok := response.Message.Parts[0].(blades.ToolPart)
+	if !ok {
+		t.Fatalf("part type = %T, want blades.ToolPart", response.Message.Parts[0])
+	}
+	if got, want := toolPart.ID, "toolu_1"; got != want {
+		t.Fatalf("tool id = %q, want %q", got, want)
+	}
+	if got, want := toolPart.Name, "get_weather"; got != want {
+		t.Fatalf("tool name = %q, want %q", got, want)
+	}
+	var request map[string]any
+	if err := json.Unmarshal([]byte(toolPart.Request), &request); err != nil {
+		t.Fatalf("unmarshal tool request: %v", err)
+	}
+	if got, want := request["city"], "Paris"; got != want {
+		t.Fatalf("tool request city = %v, want %v", got, want)
+	}
+}
+
+func TestConvertClaudeToBladesTextAndToolUse(t *testing.T) {
+	t.Parallel()
+
+	message := decodeAnthropicMessage(t, `{
+		"id": "msg_2",
+		"content": [
+			{"type":"text","text":"Checking weather"},
+			{"type":"tool_use","id":"toolu_2","name":"get_weather","input":{"city":"Tokyo"}}
+		],
+		"model": "claude-sonnet-4-20250514",
+		"role": "assistant",
+		"stop_reason": "tool_use",
+		"stop_sequence": "",
+		"type": "message",
+		"usage": {
+			"cache_creation": {"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},
+			"cache_creation_input_tokens": 0,
+			"cache_read_input_tokens": 0,
+			"input_tokens": 1,
+			"output_tokens": 1,
+			"server_tool_use": {"web_search_requests":0},
+			"service_tier": "standard"
+		}
+	}`)
+
+	response, err := convertClaudeToBlades(message, blades.StatusCompleted)
+	if err != nil {
+		t.Fatalf("convertClaudeToBlades returned error: %v", err)
+	}
+	if got, want := response.Message.Role, blades.RoleTool; got != want {
+		t.Fatalf("message role = %q, want %q", got, want)
+	}
+	if got, want := len(response.Message.Parts), 2; got != want {
+		t.Fatalf("parts len = %d, want %d", got, want)
+	}
+
+	textPart, ok := response.Message.Parts[0].(blades.TextPart)
+	if !ok {
+		t.Fatalf("first part type = %T, want blades.TextPart", response.Message.Parts[0])
+	}
+	if got, want := textPart.Text, "Checking weather"; got != want {
+		t.Fatalf("first part text = %q, want %q", got, want)
+	}
+	toolPart, ok := response.Message.Parts[1].(blades.ToolPart)
+	if !ok {
+		t.Fatalf("second part type = %T, want blades.ToolPart", response.Message.Parts[1])
+	}
+	if got, want := toolPart.ID, "toolu_2"; got != want {
+		t.Fatalf("tool id = %q, want %q", got, want)
+	}
+}
+
+func decodeAnthropicMessage(t *testing.T, data string) *anthropicSDK.Message {
+	t.Helper()
+
+	var message anthropicSDK.Message
+	if err := json.Unmarshal([]byte(data), &message); err != nil {
+		t.Fatalf("unmarshal anthropic message: %v", err)
+	}
+	return &message
+}


### PR DESCRIPTION
Align Anthropic tool-call mapping with agent iteration semantics. Tool-use responses are now surfaced as tool-role messages so custom tools execute reliably.

Also add regression tests for request and response tool message conversion to prevent role mapping regressions.

Fixes #186.