### PR TITLE
feat(skills): support binary assets and enforce size limits

### DIFF
--- a/skills/loader.go
+++ b/skills/loader.go
@@ -152,7 +152,7 @@ func loadFS(fsys fs.FS, root string) (Skill, error) {
 	if err != nil {
 		return nil, err
 	}
-	assets, binAssets, err := loadDirFiles(fsys, path.Join(root, "assets"))
+	assets, err := loadDirFiles(fsys, path.Join(root, "assets"))
 	if err != nil {
 		return nil, err
 	}
@@ -164,10 +164,9 @@ func loadFS(fsys fs.FS, root string) (Skill, error) {
 		frontmatter: frontmatter,
 		instruction: body,
 		resources: Resources{
-			References:   references,
-			Assets:       assets,
-			Scripts:      scripts,
-			BinaryAssets: binAssets,
+			References: references,
+			Assets:     assets,
+			Scripts:    scripts,
 		},
 	}, nil
 }
@@ -301,9 +300,8 @@ func loadDirTextFiles(fsys fs.FS, dir string) (map[string]string, error) {
 	return files, nil
 }
 
-func loadDirFiles(fsys fs.FS, dir string) (text map[string]string, binary map[string][]byte, err error) {
-	text = make(map[string]string)
-	binary = make(map[string][]byte)
+func loadDirFiles(fsys fs.FS, dir string) (map[string][]byte, error) {
+	files := make(map[string][]byte)
 	walkErr := fs.WalkDir(fsys, dir, func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
@@ -319,15 +317,11 @@ func loadDirFiles(fsys fs.FS, dir string) (text map[string]string, binary map[st
 		if err != nil {
 			return fmt.Errorf("file %q in %s: %w", rel, dir, err)
 		}
-		if utf8.Valid(b) {
-			text[rel] = string(b)
-		} else {
-			binary[rel] = b
-		}
+		files[rel] = b
 		return nil
 	})
 	if walkErr != nil && !errors.Is(walkErr, fs.ErrNotExist) {
-		return nil, nil, walkErr
+		return nil, walkErr
 	}
-	return text, binary, nil
+	return files, nil
 }

--- a/skills/loader_test.go
+++ b/skills/loader_test.go
@@ -490,10 +490,14 @@ Do this.`), 0o644); err != nil {
 		t.Fatalf("expected 1 skill, got %d", len(skillList))
 	}
 	resources := skillList[0].(ResourcesProvider).Resources()
-	if _, ok := resources.GetAsset("text.txt"); !ok {
+	assetData, ok := resources.GetAsset("text.txt")
+	if !ok {
 		t.Fatalf("expected text asset text.txt")
 	}
-	binData, ok := resources.GetBinaryAsset("image.bin")
+	if string(assetData) != "hello" {
+		t.Fatalf("unexpected text asset content: %q", string(assetData))
+	}
+	binData, ok := resources.GetAsset("image.bin")
 	if !ok {
 		t.Fatalf("expected binary asset image.bin")
 	}

--- a/skills/models.go
+++ b/skills/models.go
@@ -41,10 +41,8 @@ func (f Frontmatter) Validate() error {
 // Resources keeps skill files by relative path.
 type Resources struct {
 	References map[string]string
-	Assets     map[string]string
+	Assets     map[string][]byte
 	Scripts    map[string]string
-
-	BinaryAssets map[string][]byte
 }
 
 func (r Resources) GetReference(path string) (string, bool) {
@@ -52,7 +50,7 @@ func (r Resources) GetReference(path string) (string, bool) {
 	return v, ok
 }
 
-func (r Resources) GetAsset(path string) (string, bool) {
+func (r Resources) GetAsset(path string) ([]byte, bool) {
 	v, ok := r.Assets[path]
 	return v, ok
 }
@@ -74,28 +72,7 @@ func (r Resources) ListScripts() []string {
 	return listKeys(r.Scripts)
 }
 
-func (r Resources) GetBinaryAsset(path string) ([]byte, bool) {
-	v, ok := r.BinaryAssets[path]
-	return v, ok
-}
-
-func (r Resources) ListBinaryAssets() []string {
-	return listByteKeys(r.BinaryAssets)
-}
-
-func listKeys(m map[string]string) []string {
-	if len(m) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
-func listByteKeys(m map[string][]byte) []string {
+func listKeys[V any](m map[string]V) []string {
 	if len(m) == 0 {
 		return nil
 	}

--- a/skills/models_test.go
+++ b/skills/models_test.go
@@ -68,7 +68,7 @@ func TestResourcesList(t *testing.T) {
 
 	r := Resources{
 		References: map[string]string{"b.md": "b", "a.md": "a"},
-		Assets:     map[string]string{"x.txt": "x"},
+		Assets:     map[string][]byte{"x.txt": []byte("x")},
 		Scripts:    map[string]string{"run.sh": "echo hi"},
 	}
 	refs := r.ListReferences()

--- a/skills/toolset.go
+++ b/skills/toolset.go
@@ -76,9 +76,6 @@ func NewToolset(skills []Skill) (*Toolset, error) {
 			return nil, fmt.Errorf("skills: duplicate skill name %q", skill.Name())
 		}
 		resources := resolveResources(skill)
-		if err := validateResources(resources, skill.Name()); err != nil {
-			return nil, err
-		}
 		ts.skillByName[skill.Name()] = skillEntry{
 			skill:       skill,
 			frontmatter: frontmatter,
@@ -141,15 +138,6 @@ func resolveResources(skill Skill) Resources {
 		return Resources{}
 	}
 	return provider.Resources()
-}
-
-func validateResources(resources Resources, skillName string) error {
-	for rel := range resources.BinaryAssets {
-		if _, exists := resources.Assets[rel]; exists {
-			return fmt.Errorf("skills: asset %q in skill %q exists in both assets and binary assets", rel, skillName)
-		}
-	}
-	return nil
 }
 
 // Tools returns skill tools.
@@ -251,9 +239,6 @@ func toResourcesList(r Resources) []string {
 		out = add("references/"+name, out)
 	}
 	for _, name := range r.ListAssets() {
-		out = add("assets/"+name, out)
-	}
-	for _, name := range r.ListBinaryAssets() {
 		out = add("assets/"+name, out)
 	}
 	for _, name := range r.ListScripts() {
@@ -399,36 +384,40 @@ func (t *loadSkillResourceTool) Handle(ctx context.Context, input string) (strin
 		}), nil
 	}
 	resources := skill.resources
-	var (
-		content string
-		found   bool
-	)
 	switch resourceType {
 	case "references":
-		content, found = resources.GetReference(resourceName)
-	case "assets":
-		content, found = resources.GetAsset(resourceName)
-	case "scripts":
-		content, found = resources.GetScript(resourceName)
-	default:
-		return invalidArgs("Invalid resource type"), nil
-	}
-	if found {
+		content, found := resources.GetReference(resourceName)
+		if !found {
+			break
+		}
 		return mustJSON(map[string]any{
 			"skill_name": req.SkillName,
 			"path":       req.Path,
 			"content":    content,
 		}), nil
-	}
-	if resourceType == "assets" {
-		if binData, ok := resources.GetBinaryAsset(resourceName); ok {
-			return mustJSON(map[string]any{
-				"skill_name":     req.SkillName,
-				"path":           req.Path,
-				"content_base64": base64.StdEncoding.EncodeToString(binData),
-				"encoding":       "base64",
-			}), nil
+	case "assets":
+		data, found := resources.GetAsset(resourceName)
+		if !found {
+			break
 		}
+		return mustJSON(map[string]any{
+			"skill_name":     req.SkillName,
+			"path":           req.Path,
+			"content_base64": base64.StdEncoding.EncodeToString(data),
+			"encoding":       "base64",
+		}), nil
+	case "scripts":
+		content, found := resources.GetScript(resourceName)
+		if !found {
+			break
+		}
+		return mustJSON(map[string]any{
+			"skill_name": req.SkillName,
+			"path":       req.Path,
+			"content":    content,
+		}), nil
+	default:
+		return invalidArgs("Invalid resource type"), nil
 	}
 	return mustJSON(map[string]any{
 		"error":      fmt.Sprintf("Resource %q not found in skill %q.", req.Path, req.SkillName),
@@ -617,11 +606,6 @@ func materializeSkillWorkspace(root string, resources Resources) error {
 		}
 	}
 	for rel, content := range resources.Assets {
-		if err := writeWorkspaceFile(root, "assets", rel, []byte(content), 0o644); err != nil {
-			return err
-		}
-	}
-	for rel, content := range resources.BinaryAssets {
 		if err := writeWorkspaceFile(root, "assets", rel, content, 0o644); err != nil {
 			return err
 		}

--- a/skills/toolset_test.go
+++ b/skills/toolset_test.go
@@ -43,7 +43,7 @@ func TestSkillTools(t *testing.T) {
 		instruction: "Do something",
 		resources: Resources{
 			References: map[string]string{"ref.md": "ref"},
-			Assets:     map[string]string{"asset.txt": "asset"},
+			Assets:     map[string][]byte{"asset.txt": []byte("asset")},
 			Scripts:    map[string]string{"run.sh": "echo"},
 		},
 	}
@@ -575,7 +575,7 @@ func TestLoadSkillReturnsResourcesList(t *testing.T) {
 		instruction: "Do something",
 		resources: Resources{
 			References: map[string]string{"ref.md": "ref content"},
-			Assets:     map[string]string{"tmpl.txt": "template"},
+			Assets:     map[string][]byte{"tmpl.txt": []byte("template")},
 			Scripts:    map[string]string{"run.sh": "echo ok"},
 		},
 	}
@@ -718,7 +718,7 @@ func TestLoadSkillResourceBinaryAssetBase64(t *testing.T) {
 		frontmatter: Frontmatter{Name: "skill1", Description: "Skill 1"},
 		instruction: "",
 		resources: Resources{
-			BinaryAssets: map[string][]byte{"image.png": binData},
+			Assets: map[string][]byte{"image.png": binData},
 		},
 	}
 	toolset, err := NewToolset([]Skill{skill})
@@ -762,8 +762,10 @@ func TestLoadSkillResourceTextAssetPreferredOverBinary(t *testing.T) {
 		frontmatter: Frontmatter{Name: "skill1", Description: "Skill 1"},
 		instruction: "",
 		resources: Resources{
-			Assets:       map[string]string{"readme.txt": "hello text"},
-			BinaryAssets: map[string][]byte{"image.png": {0xFF, 0xFE}},
+			Assets: map[string][]byte{
+				"readme.txt": []byte("hello text"),
+				"image.png":  {0xFF, 0xFE},
+			},
 		},
 	}
 	toolset, err := NewToolset([]Skill{skill})
@@ -772,7 +774,7 @@ func TestLoadSkillResourceTextAssetPreferredOverBinary(t *testing.T) {
 	}
 	tool := toolset.Tools()[2]
 
-	// Text asset returns content field.
+	// Text asset returns content_base64 field.
 	resp, err := tool.Handle(context.Background(), `{"skill_name":"skill1","path":"assets/readme.txt"}`)
 	if err != nil {
 		t.Fatalf("tool error: %v", err)
@@ -781,11 +783,19 @@ func TestLoadSkillResourceTextAssetPreferredOverBinary(t *testing.T) {
 	if err := json.Unmarshal([]byte(resp), &obj); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if obj["content"] != "hello text" {
-		t.Fatalf("unexpected content: %v", obj["content"])
+	if obj["encoding"] != "base64" {
+		t.Fatalf("expected encoding=base64, got %v", obj["encoding"])
 	}
-	if _, hasEncoding := obj["encoding"]; hasEncoding {
-		t.Fatalf("text asset should not have encoding field")
+	encoded, ok := obj["content_base64"].(string)
+	if !ok {
+		t.Fatalf("expected content_base64 string")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	if string(decoded) != "hello text" {
+		t.Fatalf("unexpected content: %s", decoded)
 	}
 }
 
@@ -794,9 +804,11 @@ func TestMaterializeSkillWorkspaceBinaryAssets(t *testing.T) {
 
 	binData := []byte{0x89, 0x50, 0x4E, 0x47, 0xFF, 0xFE}
 	resources := Resources{
-		Assets:       map[string]string{"text.txt": "hello"},
-		BinaryAssets: map[string][]byte{"image.png": binData},
-		Scripts:      map[string]string{"run.sh": "echo ok"},
+		Assets: map[string][]byte{
+			"text.txt":  []byte("hello"),
+			"image.png": binData,
+		},
+		Scripts: map[string]string{"run.sh": "echo ok"},
 	}
 	root := t.TempDir()
 	if err := materializeSkillWorkspace(root, resources); err != nil {
@@ -831,10 +843,12 @@ func TestToResourcesListIncludesBinaryAssets(t *testing.T) {
 	t.Parallel()
 
 	resources := Resources{
-		References:   map[string]string{"ref.md": "ref"},
-		Assets:       map[string]string{"text.txt": "text"},
-		BinaryAssets: map[string][]byte{"image.png": {0xFF}},
-		Scripts:      map[string]string{"run.sh": "echo"},
+		References: map[string]string{"ref.md": "ref"},
+		Assets: map[string][]byte{
+			"text.txt":  []byte("text"),
+			"image.png": {0xFF},
+		},
+		Scripts: map[string]string{"run.sh": "echo"},
 	}
 	list := toResourcesList(resources)
 	want := map[string]bool{
@@ -856,12 +870,11 @@ func TestToResourcesListIncludesBinaryAssets(t *testing.T) {
 	}
 }
 
-func TestToResourcesListDeduplicatesAssetPaths(t *testing.T) {
+func TestToResourcesListEachAssetAppearsOnce(t *testing.T) {
 	t.Parallel()
 
 	resources := Resources{
-		Assets:       map[string]string{"same.txt": "text"},
-		BinaryAssets: map[string][]byte{"same.txt": {0xFF}},
+		Assets: map[string][]byte{"same.txt": []byte("text")},
 	}
 	list := toResourcesList(resources)
 	count := 0
@@ -872,27 +885,6 @@ func TestToResourcesListDeduplicatesAssetPaths(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected assets/same.txt exactly once, got %d", count)
-	}
-}
-
-func TestNewToolsetRejectsAssetPathConflictBetweenTextAndBinary(t *testing.T) {
-	t.Parallel()
-
-	_, err := NewToolset([]Skill{
-		&staticSkill{
-			frontmatter: Frontmatter{Name: "skill1", Description: "Skill 1"},
-			instruction: "",
-			resources: Resources{
-				Assets:       map[string]string{"same.txt": "text"},
-				BinaryAssets: map[string][]byte{"same.txt": {0xFF}},
-			},
-		},
-	})
-	if err == nil {
-		t.Fatalf("expected error")
-	}
-	if !strings.Contains(err.Error(), "exists in both assets and binary assets") {
-		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
add BinaryAssets support and base64 responses for binary assets

reject non-UTF-8 files in references/scripts

enforce 10MB limits for resources and script output

add conflict checks for duplicate asset paths and expand tests