### PR TITLE
fix(skills): support binary skill assets

### DIFF
--- a/skills/models.go
+++ b/skills/models.go
@@ -41,7 +41,7 @@ func (f Frontmatter) Validate() error {
 // Resources keeps skill files by relative path.
 type Resources struct {
 	References map[string]string
-	Assets     map[string]string
+	Assets     map[string][]byte
 	Scripts    map[string]string
 }
 
@@ -50,7 +50,7 @@ func (r Resources) GetReference(path string) (string, bool) {
 	return v, ok
 }
 
-func (r Resources) GetAsset(path string) (string, bool) {
+func (r Resources) GetAsset(path string) ([]byte, bool) {
 	v, ok := r.Assets[path]
 	return v, ok
 }
@@ -72,7 +72,7 @@ func (r Resources) ListScripts() []string {
 	return listKeys(r.Scripts)
 }
 
-func listKeys(m map[string]string) []string {
+func listKeys[T any](m map[string]T) []string {
 	if len(m) == 0 {
 		return nil
 	}

--- a/skills/models_test.go
+++ b/skills/models_test.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -68,15 +69,19 @@ func TestResourcesList(t *testing.T) {
 
 	r := Resources{
 		References: map[string]string{"b.md": "b", "a.md": "a"},
-		Assets:     map[string]string{"x.txt": "x"},
+		Assets:     map[string][]byte{"x.txt": []byte("x")},
 		Scripts:    map[string]string{"run.sh": "echo hi"},
 	}
 	refs := r.ListReferences()
 	if len(refs) != 2 || refs[0] != "a.md" || refs[1] != "b.md" {
 		t.Fatalf("unexpected refs: %v", refs)
 	}
-	if _, ok := r.GetAsset("x.txt"); !ok {
+	asset, ok := r.GetAsset("x.txt")
+	if !ok {
 		t.Fatalf("expected asset x.txt")
+	}
+	if !bytes.Equal(asset, []byte("x")) {
+		t.Fatalf("unexpected asset content: %q", string(asset))
 	}
 	if _, ok := r.GetScript("run.sh"); !ok {
 		t.Fatalf("expected script run.sh")


### PR DESCRIPTION
Load skill assets as byte slices so image and other binary files are preserved during discovery and execution.

Unify resource loading and workspace materialization around raw bytes so assets are no longer lossy.

Update loader and toolset tests to cover binary assets and base64 resource output.