### PR TITLE
feat(metadata): enhance metadata handling with nested structures and …

### DIFF
--- a/skills/loader.go
+++ b/skills/loader.go
@@ -254,9 +254,7 @@ func parseFrontmatter(content string) (Frontmatter, error) {
 	if raw == nil {
 		return Frontmatter{}, fmt.Errorf("skills: frontmatter must be a mapping")
 	}
-	f := Frontmatter{
-		Metadata: make(map[string]string),
-	}
+	f := Frontmatter{}
 	name, ok := raw["name"].(string)
 	if !ok {
 		return Frontmatter{}, fmt.Errorf("skills: name must be a string")
@@ -296,17 +294,11 @@ func parseFrontmatter(content string) (Frontmatter, error) {
 		f.AllowedTools = s
 	}
 	if v, ok := raw["metadata"]; ok {
-		items, ok := v.(map[string]any)
-		if !ok {
-			return Frontmatter{}, fmt.Errorf("skills: metadata must be a map")
+		items, err := normalizeMetadataMap(v)
+		if err != nil {
+			return Frontmatter{}, err
 		}
-		for key, value := range items {
-			s, ok := value.(string)
-			if !ok {
-				return Frontmatter{}, fmt.Errorf("skills: metadata value for %q must be a string", key)
-			}
-			f.Metadata[key] = s
-		}
+		f.Metadata = items
 	}
 	return f, nil
 }

--- a/skills/loader_test.go
+++ b/skills/loader_test.go
@@ -534,3 +534,66 @@ Body`), 0o644); err != nil {
 		t.Fatalf("unexpected allowed tools: %s", fm.AllowedTools)
 	}
 }
+
+func TestReadSkillFrontmatterNestedMetadata(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "test-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: test-skill
+description: desc
+metadata:
+  source: registry
+  config:
+    timeout: 30
+    enabled: true
+    tags:
+      - fast
+      - safe
+---
+Body`), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	fm, err := ReadSkillFrontmatter(skillDir)
+	if err != nil {
+		t.Fatalf("read frontmatter: %v", err)
+	}
+	if fm.Metadata["source"] != "registry" {
+		t.Fatalf("unexpected metadata source: %v", fm.Metadata["source"])
+	}
+	config, ok := fm.Metadata["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected metadata config type: %T", fm.Metadata["config"])
+	}
+	if enabled, ok := config["enabled"].(bool); !ok || !enabled {
+		t.Fatalf("unexpected metadata config.enabled: %v", config["enabled"])
+	}
+	switch timeout := config["timeout"].(type) {
+	case int:
+		if timeout != 30 {
+			t.Fatalf("unexpected metadata config.timeout: %v", timeout)
+		}
+	case int64:
+		if timeout != 30 {
+			t.Fatalf("unexpected metadata config.timeout: %v", timeout)
+		}
+	case float64:
+		if timeout != 30 {
+			t.Fatalf("unexpected metadata config.timeout: %v", timeout)
+		}
+	default:
+		t.Fatalf("unexpected metadata config.timeout type: %T", config["timeout"])
+	}
+	tags, ok := config["tags"].([]any)
+	if !ok {
+		t.Fatalf("unexpected metadata config.tags type: %T", config["tags"])
+	}
+	if len(tags) != 2 || tags[0] != "fast" || tags[1] != "safe" {
+		t.Fatalf("unexpected metadata config.tags: %v", tags)
+	}
+}

--- a/skills/models.go
+++ b/skills/models.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 )
@@ -15,7 +16,7 @@ type Frontmatter struct {
 	License       string
 	Compatibility string
 	AllowedTools  string
-	Metadata      map[string]string
+	Metadata      map[string]any
 }
 
 // Validate validates skill frontmatter.
@@ -141,4 +142,88 @@ func (s *staticSkill) Resources() Resources {
 		return Resources{}
 	}
 	return s.resources
+}
+
+func normalizeMetadataMap(value any) (map[string]any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	normalized, err := normalizeMetadataValue(value)
+	if err != nil {
+		return nil, err
+	}
+	items, ok := normalized.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("skills: metadata must be a map")
+	}
+	return items, nil
+}
+
+func normalizeMetadataValue(value any) (any, error) {
+	switch v := value.(type) {
+	case nil, string, bool,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return v, nil
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, item := range v {
+			normalized, err := normalizeMetadataValue(item)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = normalized
+		}
+		return out, nil
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			normalized, err := normalizeMetadataValue(item)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = normalized
+		}
+		return out, nil
+	}
+
+	rv := reflect.ValueOf(value)
+	if !rv.IsValid() {
+		return nil, nil
+	}
+
+	switch rv.Kind() {
+	case reflect.Interface, reflect.Pointer:
+		if rv.IsNil() {
+			return nil, nil
+		}
+		return normalizeMetadataValue(rv.Elem().Interface())
+	case reflect.Map:
+		if rv.Type().Key().Kind() != reflect.String {
+			return nil, fmt.Errorf("skills: metadata map keys must be strings")
+		}
+		out := make(map[string]any, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			normalized, err := normalizeMetadataValue(iter.Value().Interface())
+			if err != nil {
+				return nil, err
+			}
+			out[iter.Key().String()] = normalized
+		}
+		return out, nil
+	case reflect.Slice, reflect.Array:
+		out := make([]any, rv.Len())
+		for i := range rv.Len() {
+			normalized, err := normalizeMetadataValue(rv.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+			out[i] = normalized
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("skills: metadata value of type %T is not JSON-compatible", value)
+	}
 }

--- a/skills/toolset.go
+++ b/skills/toolset.go
@@ -68,7 +68,10 @@ func NewToolset(skills []Skill) (*Toolset, error) {
 		if skill == nil {
 			continue
 		}
-		frontmatter := resolveFrontmatter(skill)
+		frontmatter, err := resolveFrontmatter(skill)
+		if err != nil {
+			return nil, err
+		}
 		if err := frontmatter.Validate(); err != nil {
 			return nil, err
 		}
@@ -109,26 +112,27 @@ func NewToolset(skills []Skill) (*Toolset, error) {
 	return ts, nil
 }
 
-func resolveFrontmatter(skill Skill) Frontmatter {
+func resolveFrontmatter(skill Skill) (Frontmatter, error) {
 	f := Frontmatter{
 		Name:        skill.Name(),
 		Description: skill.Description(),
 	}
 	provider, ok := skill.(FrontmatterProvider)
 	if !ok {
-		return f
+		return f, nil
 	}
 	frontmatter := provider.Frontmatter()
 	f.License = frontmatter.License
 	f.Compatibility = frontmatter.Compatibility
 	f.AllowedTools = frontmatter.AllowedTools
 	if len(frontmatter.Metadata) > 0 {
-		f.Metadata = make(map[string]string, len(frontmatter.Metadata))
-		for key, value := range frontmatter.Metadata {
-			f.Metadata[key] = value
+		metadata, err := normalizeMetadataMap(frontmatter.Metadata)
+		if err != nil {
+			return Frontmatter{}, err
 		}
+		f.Metadata = metadata
 	}
-	return f
+	return f, nil
 }
 
 func resolveResources(skill Skill) Resources {

--- a/skills/toolset_test.go
+++ b/skills/toolset_test.go
@@ -116,6 +116,65 @@ func TestSkillTools(t *testing.T) {
 	}
 }
 
+func TestLoadSkillPreservesNestedMetadata(t *testing.T) {
+	t.Parallel()
+
+	skill := &staticSkill{
+		frontmatter: Frontmatter{
+			Name:        "skill1",
+			Description: "Skill 1",
+			Metadata: map[string]any{
+				"source": "registry",
+				"config": map[string]any{
+					"mode":  "strict",
+					"steps": []any{"scan", "patch"},
+				},
+			},
+		},
+		instruction: "Do something",
+		resources:   Resources{},
+	}
+	toolset, err := NewToolset([]Skill{skill})
+	if err != nil {
+		t.Fatalf("new toolset: %v", err)
+	}
+
+	resp, err := toolset.Tools()[1].Handle(context.Background(), `{"name":"skill1"}`)
+	if err != nil {
+		t.Fatalf("load_skill error: %v", err)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(resp), &obj); err != nil {
+		t.Fatalf("unmarshal load response: %v", err)
+	}
+	frontmatter, ok := obj["frontmatter"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected frontmatter type: %T", obj["frontmatter"])
+	}
+	metadata, ok := frontmatter["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected metadata type: %T", frontmatter["metadata"])
+	}
+	if metadata["source"] != "registry" {
+		t.Fatalf("unexpected metadata source: %v", metadata["source"])
+	}
+	config, ok := metadata["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected config type: %T", metadata["config"])
+	}
+	if config["mode"] != "strict" {
+		t.Fatalf("unexpected config mode: %v", config["mode"])
+	}
+	steps, ok := config["steps"].([]any)
+	if !ok {
+		t.Fatalf("unexpected config.steps type: %T", config["steps"])
+	}
+	if len(steps) != 2 || steps[0] != "scan" || steps[1] != "patch" {
+		t.Fatalf("unexpected config.steps: %v", steps)
+	}
+}
+
 func TestLoadSkillResourceErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Example:

```yaml
---
name: github
description: "GitHub operations via `gh` CLI: issues, PRs, CI runs, code review, API queries. Use when: (1) checking PR status or CI, (2) creating/commenting on issues, (3) listing/filtering PRs or issues, (4) viewing run logs. NOT for: complex web UI interactions requiring manual browser flows (use browser tooling when available), bulk operations across many repos (script with gh api), or when gh auth is not configured."
metadata:
  {
    "openclaw":
      {
        "emoji": "🐙",
        "requires": { "bins": ["gh"] },
        "install":
          [
            {
              "id": "brew",
              "kind": "brew",
              "formula": "gh",
              "bins": ["gh"],
              "label": "Install GitHub CLI (brew)",
            },
            {
              "id": "apt",
              "kind": "apt",
              "package": "gh",
              "bins": ["gh"],
              "label": "Install GitHub CLI (apt)",
            },
          ],
      },
  }
---
```