### PR TITLE
fix: strip only text parts from completed stream messages to prevent duplicate output

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -408,13 +408,21 @@ func (a *agent) handle(ctx context.Context, session Session, invocation *Invocat
 						finalMessage.Author = a.name
 					}
 					finalMessage.InvocationID = invocation.ID
-					// When incremental chunks have already been yielded, skip the
-					// final completed message to avoid sending duplicate accumulated
-					// text. If no chunks were yielded yet, deliver the completed
-					// message so that completed-only providers still produce output.
+					// When incremental chunks have already been yielded, strip text
+					// parts from the completed message to avoid duplicate output
+					// while still yielding it as a completion signal so consumers
+					// can access status and metadata. Completed-only providers
+					// (no prior chunks) retain their text.
 					if finalMessage.Status == StatusCompleted {
 						a.saveOutputState(ctx, invocation, finalMessage)
 						if hasChunks {
+							// Yield a copy with text stripped to avoid duplicate
+							// output while preserving the original for session state.
+							signal := *finalMessage
+							signal.Parts = nil
+							if !yield(&signal, nil) {
+								return // early termination
+							}
 							continue
 						}
 					}

--- a/agent.go
+++ b/agent.go
@@ -393,6 +393,7 @@ func (a *agent) handle(ctx context.Context, session Session, invocation *Invocat
 				}
 			} else {
 				streaming := a.model.NewStreaming(ctx, req)
+				hasChunks := false
 				for response, err := range streaming {
 					if err != nil {
 						yield(nil, err)
@@ -407,10 +408,18 @@ func (a *agent) handle(ctx context.Context, session Session, invocation *Invocat
 						finalMessage.Author = a.name
 					}
 					finalMessage.InvocationID = invocation.ID
-					// Skip completed messages; only yield incremental chunks.
+					// When incremental chunks have already been yielded, skip the
+					// final completed message to avoid sending duplicate accumulated
+					// text. If no chunks were yielded yet, deliver the completed
+					// message so that completed-only providers still produce output.
 					if finalMessage.Status == StatusCompleted {
 						a.saveOutputState(ctx, invocation, finalMessage)
-						continue
+						if hasChunks {
+							continue
+						}
+					}
+					if finalMessage.Status == StatusIncomplete {
+						hasChunks = true
 					}
 					if !yield(finalMessage, nil) {
 						return // early termination

--- a/agent.go
+++ b/agent.go
@@ -420,13 +420,17 @@ func (a *agent) handle(ctx context.Context, session Session, invocation *Invocat
 							// duplicate output while preserving non-text parts
 							// (e.g., ToolPart, FilePart, DataPart) and metadata.
 							signal := *finalMessage
-							filtered := signal.Parts[:0:0]
+							var filtered []Part
 							for _, part := range signal.Parts {
 								if _, ok := part.(TextPart); !ok {
 									filtered = append(filtered, part)
 								}
 							}
-							signal.Parts = filtered
+							if len(filtered) == 0 {
+								signal.Parts = nil
+							} else {
+								signal.Parts = filtered
+							}
 							if !yield(&signal, nil) {
 								return // early termination
 							}

--- a/agent.go
+++ b/agent.go
@@ -407,11 +407,11 @@ func (a *agent) handle(ctx context.Context, session Session, invocation *Invocat
 						finalMessage.Author = a.name
 					}
 					finalMessage.InvocationID = invocation.ID
-					// Skip saving tool intermediate states
-					if finalMessage.Role == RoleTool && finalMessage.Status == StatusCompleted {
+					// Skip completed messages; only yield incremental chunks.
+					if finalMessage.Status == StatusCompleted {
+						a.saveOutputState(ctx, invocation, finalMessage)
 						continue
 					}
-					a.saveOutputState(ctx, invocation, finalMessage)
 					if !yield(finalMessage, nil) {
 						return // early termination
 					}

--- a/agent.go
+++ b/agent.go
@@ -416,10 +416,17 @@ func (a *agent) handle(ctx context.Context, session Session, invocation *Invocat
 					if finalMessage.Status == StatusCompleted {
 						a.saveOutputState(ctx, invocation, finalMessage)
 						if hasChunks {
-							// Yield a copy with text stripped to avoid duplicate
-							// output while preserving the original for session state.
+							// Yield a copy with only text parts stripped to avoid
+							// duplicate output while preserving non-text parts
+							// (e.g., ToolPart, FilePart, DataPart) and metadata.
 							signal := *finalMessage
-							signal.Parts = nil
+							filtered := signal.Parts[:0:0]
+							for _, part := range signal.Parts {
+								if _, ok := part.(TextPart); !ok {
+									filtered = append(filtered, part)
+								}
+							}
+							signal.Parts = filtered
 							if !yield(&signal, nil) {
 								return // early termination
 							}

--- a/agent_stream_test.go
+++ b/agent_stream_test.go
@@ -156,14 +156,48 @@ func TestRunnerRunStream_AllowsIncompleteThenCompleted(t *testing.T) {
 	if gotErr != nil {
 		t.Fatalf("expected no error, got %v", gotErr)
 	}
-	if got, want := len(statuses), 2; got != want {
+	// Only the incomplete chunk is yielded; the completed message is consumed internally.
+	if got, want := len(statuses), 1; got != want {
 		t.Fatalf("statuses len = %d, want %d", got, want)
 	}
 	if got, want := statuses[0], StatusIncomplete; got != want {
 		t.Fatalf("first status = %q, want %q", got, want)
 	}
-	if got, want := statuses[1], StatusCompleted; got != want {
-		t.Fatalf("second status = %q, want %q", got, want)
+}
+
+func TestRunnerRunStream_NoDuplicateOutput(t *testing.T) {
+	t.Parallel()
+
+	model := &scriptedStreamingModel{
+		streamResponses: []*ModelResponse{
+			streamingResponse(StatusIncomplete, "chunk1"),
+			streamingResponse(StatusIncomplete, "chunk2"),
+			streamingResponse(StatusCompleted, "chunk1chunk2"),
+		},
+	}
+	agent, err := NewAgent("stream-agent", WithModel(model))
+	if err != nil {
+		t.Fatalf("new agent: %v", err)
+	}
+	runner := NewRunner(agent)
+
+	var texts []string
+	for output, err := range runner.RunStream(context.Background(), UserMessage("hi")) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, p := range output.Parts {
+			if tp, ok := p.(TextPart); ok {
+				texts = append(texts, tp.Text)
+			}
+		}
+	}
+
+	if got, want := len(texts), 2; got != want {
+		t.Fatalf("texts len = %d, want %d; got %v", got, want, texts)
+	}
+	if texts[0] != "chunk1" || texts[1] != "chunk2" {
+		t.Fatalf("texts = %v, want [chunk1, chunk2]", texts)
 	}
 }
 

--- a/agent_stream_test.go
+++ b/agent_stream_test.go
@@ -156,12 +156,16 @@ func TestRunnerRunStream_AllowsIncompleteThenCompleted(t *testing.T) {
 	if gotErr != nil {
 		t.Fatalf("expected no error, got %v", gotErr)
 	}
-	// Only the incomplete chunk is yielded; the completed message is consumed internally.
-	if got, want := len(statuses), 1; got != want {
-		t.Fatalf("statuses len = %d, want %d", got, want)
+	// Both the incomplete and completed messages are yielded; the completed
+	// message has its text stripped to avoid duplicating the incremental chunks.
+	if got, want := len(statuses), 2; got != want {
+		t.Fatalf("statuses len = %d, want %d; got %v", got, want, statuses)
 	}
 	if got, want := statuses[0], StatusIncomplete; got != want {
 		t.Fatalf("first status = %q, want %q", got, want)
+	}
+	if got, want := statuses[1], StatusCompleted; got != want {
+		t.Fatalf("second status = %q, want %q", got, want)
 	}
 }
 
@@ -181,11 +185,15 @@ func TestRunnerRunStream_NoDuplicateOutput(t *testing.T) {
 	}
 	runner := NewRunner(agent)
 
-	var texts []string
+	var (
+		texts    []string
+		statuses []Status
+	)
 	for output, err := range runner.RunStream(context.Background(), UserMessage("hi")) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		statuses = append(statuses, output.Status)
 		for _, p := range output.Parts {
 			if tp, ok := p.(TextPart); ok {
 				texts = append(texts, tp.Text)
@@ -193,6 +201,14 @@ func TestRunnerRunStream_NoDuplicateOutput(t *testing.T) {
 		}
 	}
 
+	// All three messages are yielded, but the completed one has text stripped.
+	if got, want := len(statuses), 3; got != want {
+		t.Fatalf("statuses len = %d, want %d; got %v", got, want, statuses)
+	}
+	if got, want := statuses[2], StatusCompleted; got != want {
+		t.Fatalf("last status = %q, want %q", got, want)
+	}
+	// Only the two incomplete chunks contribute text — no duplicate.
 	if got, want := len(texts), 2; got != want {
 		t.Fatalf("texts len = %d, want %d; got %v", got, want, texts)
 	}

--- a/agent_stream_test.go
+++ b/agent_stream_test.go
@@ -217,6 +217,66 @@ func TestRunnerRunStream_NoDuplicateOutput(t *testing.T) {
 	}
 }
 
+func TestRunnerRunStream_CompletedSignalRetainsNonTextParts(t *testing.T) {
+	t.Parallel()
+
+	// Build a completed response that carries both text and a tool part.
+	completedResp := streamingResponse(StatusCompleted, "chunk1")
+	completedResp.Message.Parts = append(completedResp.Message.Parts,
+		NewToolPart("t1", "myTool", `{"arg":"val"}`),
+	)
+
+	model := &scriptedStreamingModel{
+		streamResponses: []*ModelResponse{
+			streamingResponse(StatusIncomplete, "chunk1"),
+			completedResp,
+		},
+	}
+	agent, err := NewAgent("stream-agent", WithModel(model))
+	if err != nil {
+		t.Fatalf("new agent: %v", err)
+	}
+	runner := NewRunner(agent)
+
+	var (
+		texts     []string
+		toolParts []ToolPart
+		statuses  []Status
+	)
+	for output, err := range runner.RunStream(context.Background(), UserMessage("hi")) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		statuses = append(statuses, output.Status)
+		for _, p := range output.Parts {
+			switch v := p.(type) {
+			case TextPart:
+				texts = append(texts, v.Text)
+			case ToolPart:
+				toolParts = append(toolParts, v)
+			}
+		}
+	}
+
+	if got, want := len(statuses), 2; got != want {
+		t.Fatalf("statuses len = %d, want %d; got %v", got, want, statuses)
+	}
+	if got, want := statuses[1], StatusCompleted; got != want {
+		t.Fatalf("last status = %q, want %q", got, want)
+	}
+	// Text is only from the incomplete chunk — no duplicate.
+	if got, want := len(texts), 1; got != want {
+		t.Fatalf("texts len = %d, want %d; got %v", got, want, texts)
+	}
+	// ToolPart from the completed message must be preserved.
+	if got, want := len(toolParts), 1; got != want {
+		t.Fatalf("toolParts len = %d, want %d", got, want)
+	}
+	if got, want := toolParts[0].Name, "myTool"; got != want {
+		t.Fatalf("toolPart name = %q, want %q", got, want)
+	}
+}
+
 func TestRunnerRunStream_CompletedOnlyYieldsOutput(t *testing.T) {
 	t.Parallel()
 

--- a/agent_stream_test.go
+++ b/agent_stream_test.go
@@ -201,6 +201,42 @@ func TestRunnerRunStream_NoDuplicateOutput(t *testing.T) {
 	}
 }
 
+func TestRunnerRunStream_CompletedOnlyYieldsOutput(t *testing.T) {
+	t.Parallel()
+
+	model := &scriptedStreamingModel{
+		streamResponses: []*ModelResponse{
+			streamingResponse(StatusCompleted, "hello"),
+		},
+	}
+	agent, err := NewAgent("stream-agent", WithModel(model))
+	if err != nil {
+		t.Fatalf("new agent: %v", err)
+	}
+	runner := NewRunner(agent)
+
+	var statuses []Status
+	var texts []string
+	for output, err := range runner.RunStream(context.Background(), UserMessage("hi")) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		statuses = append(statuses, output.Status)
+		texts = append(texts, output.Text())
+	}
+
+	// A provider that only emits a single completed message must still produce output.
+	if got, want := len(statuses), 1; got != want {
+		t.Fatalf("statuses len = %d, want %d; got %v", got, want, statuses)
+	}
+	if got, want := statuses[0], StatusCompleted; got != want {
+		t.Fatalf("status = %q, want %q", got, want)
+	}
+	if got, want := texts[0], "hello"; got != want {
+		t.Fatalf("text = %q, want %q", got, want)
+	}
+}
+
 func TestRunnerRunStream_ReturnsNoFinalResponseWhenChunkMessageNil(t *testing.T) {
 	t.Parallel()
 

--- a/runner_session_test.go
+++ b/runner_session_test.go
@@ -35,10 +35,18 @@ func (m *countingSessionModel) NewStreaming(context.Context, *ModelRequest) Gene
 	m.mu.Unlock()
 
 	return func(yield func(*ModelResponse, error) bool) {
-		msg := NewAssistantMessage(StatusCompleted)
-		msg.ID = "shared-stream-message-id"
-		msg.Parts = append(msg.Parts, TextPart{Text: fmt.Sprintf("stream-%d", call)})
-		yield(&ModelResponse{Message: msg}, nil)
+		text := fmt.Sprintf("stream-%d", call)
+		// Emit an incomplete chunk first, then the completed message.
+		inc := NewAssistantMessage(StatusIncomplete)
+		inc.ID = "shared-stream-message-id"
+		inc.Parts = append(inc.Parts, TextPart{Text: text})
+		if !yield(&ModelResponse{Message: inc}, nil) {
+			return
+		}
+		done := NewAssistantMessage(StatusCompleted)
+		done.ID = "shared-stream-message-id"
+		done.Parts = append(done.Parts, TextPart{Text: text})
+		yield(&ModelResponse{Message: done}, nil)
 	}
 }
 

--- a/runner_session_test.go
+++ b/runner_session_test.go
@@ -145,10 +145,12 @@ func TestRunnerRunStream_RerunsWithSameSession(t *testing.T) {
 		secondTexts = append(secondTexts, output.Text())
 	}
 
-	if got, want := len(firstTexts), 1; got != want {
+	// Two messages per stream: the incomplete chunk (with text) and the
+	// completed signal (text stripped to avoid duplication).
+	if got, want := len(firstTexts), 2; got != want {
 		t.Fatalf("first stream output len = %d, want %d", got, want)
 	}
-	if got, want := len(secondTexts), 1; got != want {
+	if got, want := len(secondTexts), 2; got != want {
 		t.Fatalf("second stream output len = %d, want %d", got, want)
 	}
 	if got, want := firstTexts[0], "stream-1"; got != want {


### PR DESCRIPTION
Fixes #224

`handle()` in agent.go yields both `StatusIncomplete` chunks and the final
`StatusCompleted` message to the consumer during streaming. The completed
message contains the full accumulated text, so consumers see every token
twice: once incrementally, once in the final message.

When incremental chunks have been yielded, the completed message is now
delivered as a **completion signal** with only `TextPart` entries removed —
non-text parts (`ToolPart`, `FilePart`, `DataPart`) and all metadata are
preserved. Providers that only emit a single completed message (no prior
chunks) still deliver full output unchanged.

`saveOutputState()` is called before stripping so the original completed
message (with all parts) is persisted for session state and tool calls.

Tests updated to match:
- `TestRunnerRunStream_AllowsIncompleteThenCompleted` expects both statuses
- `TestRunnerRunStream_NoDuplicateOutput` verifies text deduplication
- `TestRunnerRunStream_CompletedSignalRetainsNonTextParts` verifies ToolPart
  survives the text stripping
- `TestRunnerRunStream_CompletedOnlyYieldsOutput` ensures completed-only
  providers still produce output

Pre-existing test failure `TestWithContextFalse_DefaultStateless` is from #223, not this change.