### PR TITLE
chore(agents): generalize repository skills

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: code-review
-description: Review Blades pull requests for correctness, Go quality, tests, documentation, security, and performance.
+description: Review pull requests for correctness, maintainability, tests, documentation, security, and performance.
 ---
 
 # Code Review
 
-Use this skill for GitHub Actions PR review in the Blades repository.
+Use this skill for GitHub PR review in any repository.
 
 ## Goal
 
@@ -28,35 +28,34 @@ Provide concise, actionable PR feedback. Prioritize bugs, regressions, security 
 - Do not request tests that only duplicate existing coverage. Ask for tests when a distinct behavior, edge case, regression, public API contract, race, or failure path changed.
 - If there are no actionable findings, say that no blocking issues were found and mention any important test gap.
 
-## Blades-Specific Review Rules
+## General Review Rules
 
-- Go code must be idiomatic and `gofmt` clean.
+- Code should follow the repository's established language idioms, formatting, naming, and local patterns.
 - Public APIs should preserve compatibility unless the PR clearly documents a breaking change.
-- Context-aware operations should respect `context.Context` cancellation and deadlines.
-- Streaming, runner, graph, flow, session, memory, and tool execution code must avoid data races, leaked goroutines, blocked sends, unclosed streams, and duplicate tool/result handling.
-- Skills must keep `SKILL.md` frontmatter valid: lowercase kebab-case name, non-empty description, and resource files under `references/`, `assets/`, or `scripts/`.
-- Recipe changes must preserve validation errors for duplicate names, invalid execution modes, missing tools, and bad parameter wiring.
-- Provider integrations under `contrib/` should keep provider-specific behavior isolated and should not weaken core abstractions.
-- CLI changes under `cmd/blades` should preserve workspace/home separation, never overwrite user files during init, and keep destructive commands explicit.
+- Cancellable, async, or long-running operations should respect the repository's cancellation, timeout, and cleanup conventions.
+- Concurrent, streaming, session, queue, cache, and background worker code must avoid data races, leaked tasks, blocked sends, unclosed streams, and duplicate result handling.
+- Configuration, recipe, manifest, or plugin changes must preserve validation for duplicate names, invalid modes, missing dependencies, and bad parameter wiring.
+- Integration or adapter code should keep provider-specific behavior isolated and should not weaken shared abstractions.
+- CLI or file-writing changes should preserve workspace/home separation, avoid overwriting user files unexpectedly, and keep destructive commands explicit.
 - Middleware and retry logic should not retry non-idempotent actions silently.
-- Tests should use table-driven cases and `t.Run` where it improves clarity. Use `t.Parallel()` only when the test has no shared mutable state or global environment coupling.
+- Tests should follow repository conventions and isolate shared mutable state, global environment changes, filesystem writes, network calls, and timing-sensitive behavior.
 
 ## Security Review Focus
 
 - Do not expose API keys, tokens, environment secrets, or private file contents in logs or errors.
 - Watch for command injection, path traversal, unsafe workspace escapes, and accidental writes outside configured roots.
-- Validate external inputs from config, YAML recipes, model/provider responses, MCP servers, and channel integrations.
+- Validate external inputs from configuration files, manifests, network responses, provider or plugin responses, and integration boundaries.
 - Prefer least-privilege behavior for tools and GitHub automation.
 
 ## Performance Review Focus
 
-- Flag unbounded memory growth in conversation history, summaries, streams, and logs.
+- Flag unbounded memory growth in accumulated state, caches, histories, streams, queues, and logs.
 - Flag O(n^2) behavior only when input size can plausibly grow enough to matter.
-- Watch for repeated filesystem scans, repeated model/tool registry construction, and avoidable blocking in streaming paths.
+- Watch for repeated filesystem scans, repeated expensive initialization, unnecessary network calls, and avoidable blocking in streaming or request paths.
 
 ## Documentation Review Focus
 
-- Public API changes should update README, package docs, examples, or comments when users would otherwise be misled.
+- Public API changes should update README, API docs, examples, or comments when users would otherwise be misled.
 - Examples should compile or be clearly marked as illustrative.
 - Do not require docs for internal-only refactors unless behavior changed.
 

--- a/.agents/skills/issue-deduplication/SKILL.md
+++ b/.agents/skills/issue-deduplication/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: issue-deduplication
-description: Detect high-confidence duplicate Blades GitHub issues and link them to the canonical issue.
+description: Detect high-confidence duplicate GitHub issues and link them to the canonical issue.
 ---
 
 # Issue Deduplication
 
-Use this skill for GitHub Actions duplicate detection on newly opened Blades issues.
+Use this skill for GitHub issue duplicate detection in any repository.
 
 ## Goal
 
@@ -26,10 +26,10 @@ Find true duplicates, not merely related issues. Only mark an issue as duplicate
 
 ## Normalization
 
-- Ignore low-signal prefixes such as `[Bug]`, `[Feature]`, `[Proposal]`, `[Question]`, `Bug:`, `Feature:`, and `Blades:`.
-- Treat Go version, OS, provider, and CLI flags as supporting evidence. They are duplicate blockers only when they materially change the failing behavior.
+- Ignore low-signal prefixes such as `[Bug]`, `[Feature]`, `[Proposal]`, `[Question]`, `Bug:`, `Feature:`, and repository or product names.
+- Treat runtime/dependency versions, OS, integrations, providers, and CLI flags as supporting evidence. They are duplicate blockers only when they materially change the failing behavior.
 - Treat wording differences as irrelevant when the same API, command, package, error, and reproduction path are involved.
-- Do not collapse separate Blades surfaces just because they share broad terms such as agent, model, provider, tool, recipe, graph, flow, memory, or skill.
+- Do not collapse separate product areas or components just because they share broad domain terms.
 
 ## High-Confidence Duplicate Criteria
 

--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: issue-triage
-description: Triage newly opened Blades GitHub issues by applying existing repository labels without posting comments.
+description: Triage newly opened GitHub issues by applying existing repository labels without posting comments.
 ---
 
 # Issue Triage
 
-Use this skill for GitHub Actions issue triage in the Blades repository.
+Use this skill for GitHub issue triage in any repository.
 
 ## Goal
 
@@ -25,7 +25,7 @@ Apply accurate existing labels to a newly opened issue. Do not comment on the is
 4. Infer issue type from the template, title prefix, body headings, and user intent.
 5. Apply only labels that exist in the live repository label list.
 
-## Blades Labeling Rules
+## Labeling Rules
 
 - Preserve labels already added by issue templates unless they are clearly wrong.
 - Treat the live repository label list as the source of truth. Do not invent labels and do not assume common labels exist.
@@ -34,21 +34,20 @@ Apply accurate existing labels to a newly opened issue. Do not comment on the is
   - `documentation` for docs, README, example, comment, or generated documentation issues.
   - `enhancement` for feature requests or proposals, including API shape, usage examples, or architecture ideas.
   - `question` for usage help, support questions, or clarification requests.
-  - `invalid` for reports that are clearly not actionable, not a Blades issue, or based on a false premise.
+  - `invalid` for reports that are clearly not actionable, not related to the repository, or based on a false premise.
   - `duplicate` only when another open issue is clearly the same problem.
 - If a report is incomplete, apply the best existing type label when confident. Add a status label only if the live list contains a clearly matching one.
-- Use the affected surface as routing evidence, and apply area labels only when exact matching labels exist in the live list:
-  - root framework: `agent.go`, `runner.go`, `message.go`, `model.go`, `tool.go`, `state.go`, `session.go`.
-  - `flow`, `graph`, `recipe`, `skills`, `memory`, `middleware`, `tools`, `stream`, `evaluator`.
-  - provider integrations under `contrib/openai`, `contrib/anthropic`, `contrib/gemini`, `contrib/mcp`, `contrib/otel`.
-  - CLI and runtime under `cmd/blades`.
+- Use the affected surface as routing evidence, and apply area or component labels only when exact matching labels exist in the live list:
+  - File paths, package names, modules, directories, commands, products, or integrations explicitly mentioned in the issue.
+  - Template fields, issue title prefixes, stack traces, reproduction steps, or linked code references that identify a component.
+  - Existing labels whose wording clearly matches the reported affected surface.
 - If no matching area labels exist, apply only the available type/status labels.
 
 ## Evidence Rules
 
 - Use the user's reported behavior as primary evidence. Treat guesses about root cause as hypotheses.
 - Do not ask for private API keys, account identifiers, tokens, or full unredacted logs.
-- For bugs, look for Blades version, Go version, OS, reproduction steps, expected behavior, and actual behavior.
+- For bugs, look for project version, dependency/runtime versions, OS or environment, reproduction steps, expected behavior, and actual behavior.
 - For feature requests and proposals, distinguish desired user capability from suggested implementation details.
 - For questions, prefer `question` over `bug` unless the user provides a clear failure.
 

--- a/message.go
+++ b/message.go
@@ -2,6 +2,8 @@ package blades
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -134,12 +136,20 @@ func (m *Message) Data() *DataPart {
 	return nil
 }
 
-// Clone creates a shallow copy of the message.
+// Clone creates a deep copy of the message.
 func (m *Message) Clone() *Message {
 	if m == nil {
 		return nil
 	}
-	return &(*m)
+	c := *m
+	c.Parts = slices.Clone(m.Parts)
+	if m.Actions != nil {
+		c.Actions = maps.Clone(m.Actions)
+	}
+	if m.Metadata != nil {
+		c.Metadata = maps.Clone(m.Metadata)
+	}
+	return &c
 }
 
 func (m *Message) String() string {

--- a/runner.go
+++ b/runner.go
@@ -2,6 +2,7 @@ package blades
 
 import (
 	"context"
+	"sync/atomic"
 )
 
 // RunOption defines options for configuring the Runner.
@@ -57,11 +58,12 @@ func NewRunner(rootAgent Agent, opts ...RunnerOption) *Runner {
 // buildInvocation constructs an Invocation object for the given message and options.
 func (r *Runner) buildInvocation(message *Message, stream bool, o *RunOptions) *Invocation {
 	return &Invocation{
-		ID:      o.InvocationID,
-		Session: o.Session,
-		Resume:  o.Resume,
-		Stream:  stream,
-		Message: message,
+		ID:        o.InvocationID,
+		Session:   o.Session,
+		Resume:    o.Resume,
+		Stream:    stream,
+		Message:   message,
+		committed: new(atomic.Bool),
 	}
 }
 


### PR DESCRIPTION
## Summary
Generalize repository-local agent skills so they can be reused outside Blades-specific workflows.

## Changes
- Remove Blades-specific descriptions and component routing from issue triage and deduplication skills.
- Replace Go- and repository-specific PR review rules with broader language, concurrency, configuration, integration, CLI, security, performance, and documentation guidance.

## Related Issues
N/A

## Testing
- [x] Unit tests added/updated: N/A, documentation-only skill changes
- [x] All tests pass: `make build`, `make test`
- [x] Manual testing completed: reviewed diffs and searched for Blades-specific residue

## Checklist
- [x] No sensitive data exposed
- [x] Linting and type checking passed: `git diff --check`; build/test passed
- [x] Documentation updated (if applicable)
- [x] Breaking changes documented (if applicable): N/A

## Security
- Secret scan of `.agents/skills` found only instructional references to secrets/API keys, not actual credentials.