### PR TITLE
feat(mcp): expose outgoing request middleware

### DIFF
--- a/contrib/mcp/README.md
+++ b/contrib/mcp/README.md
@@ -1,0 +1,39 @@
+# Blades MCP
+
+The MCP integration exposes remote MCP tools through the Blades
+`tools.Resolver` interface. It uses the official Go MCP SDK for transport,
+discovery, and invocation.
+
+## Dynamic request metadata
+
+Use `ClientConfig.SendingMiddleware` when outgoing MCP requests need dynamic
+metadata such as a tenant, caller, trace, or audit identity. Middleware receives
+the request context and MCP method, so it can target `tools/call` or any other
+current or future MCP request without changing tool input schemas.
+
+```go
+client, err := mcp.NewClient(mcp.ClientConfig{
+	Name:      "inventory",
+	Transport: mcp.TransportHTTP,
+	Endpoint:  "https://mcp.example.com",
+	SendingMiddleware: []sdkmcp.Middleware{
+		func(next sdkmcp.MethodHandler) sdkmcp.MethodHandler {
+			return func(ctx context.Context, method string, request sdkmcp.Request) (sdkmcp.Result, error) {
+				if method == "tools/call" {
+					meta := maps.Clone(request.GetParams().GetMeta())
+					if meta == nil {
+						meta = make(map[string]any)
+					}
+					meta["com.example/caller"] = callerFromContext(ctx)
+					request.GetParams().SetMeta(meta)
+				}
+				return next(ctx, method, request)
+			}
+		},
+	},
+})
+```
+
+The metadata is serialized in the protocol-level `_meta` field. It is not part
+of model-generated tool arguments. Use a namespaced key to avoid collisions and
+copy an existing metadata map before mutating it when middleware may share it.

--- a/contrib/mcp/client.go
+++ b/contrib/mcp/client.go
@@ -41,6 +41,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 		Name:    config.Name,
 		Version: "dev",
 	}, nil)
+	client.AddSendingMiddleware(config.SendingMiddleware...)
 	c := &Client{
 		config: config,
 		client: client,

--- a/contrib/mcp/client_test.go
+++ b/contrib/mcp/client_test.go
@@ -2,12 +2,75 @@ package mcp
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+type callerContextKey struct{}
+
+func TestSendingMiddlewareAddsCallMetadata(t *testing.T) {
+	receivedMeta := make(chan sdkmcp.Meta, 1)
+	server := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "test-server", Version: "v1"}, nil)
+	sdkmcp.AddTool(server, &sdkmcp.Tool{Name: "lookup"}, func(
+		_ context.Context,
+		request *sdkmcp.CallToolRequest,
+		input map[string]any,
+	) (*sdkmcp.CallToolResult, map[string]any, error) {
+		receivedMeta <- request.Params.Meta
+		return nil, input, nil
+	})
+	httpServer := httptest.NewServer(sdkmcp.NewStreamableHTTPHandler(
+		func(*http.Request) *sdkmcp.Server { return server },
+		nil,
+	))
+	t.Cleanup(httpServer.Close)
+
+	client, err := NewClient(ClientConfig{
+		Name:      "test-client",
+		Transport: TransportHTTP,
+		Endpoint:  httpServer.URL,
+		SendingMiddleware: []sdkmcp.Middleware{func(next sdkmcp.MethodHandler) sdkmcp.MethodHandler {
+			return func(ctx context.Context, method string, request sdkmcp.Request) (sdkmcp.Result, error) {
+				if method == "tools/call" {
+					meta := request.GetParams().GetMeta()
+					if meta == nil {
+						meta = make(map[string]any)
+					}
+					meta["caller"] = ctx.Value(callerContextKey{})
+					request.GetParams().SetMeta(meta)
+				}
+				return next(ctx, method, request)
+			}
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	_, err = client.CallTool(
+		context.WithValue(context.Background(), callerContextKey{}, "agent-1"),
+		"lookup",
+		map[string]any{"query": "weather"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case meta := <-receivedMeta:
+		if meta["caller"] != "agent-1" {
+			t.Fatalf("received caller metadata = %#v, want agent-1", meta)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive tool call metadata")
+	}
+}
 
 func TestCreateStdioTransportIncludesProcessEnv(t *testing.T) {
 	t.Setenv("BLADES_MCP_BASE_ENV", "base")

--- a/contrib/mcp/config.go
+++ b/contrib/mcp/config.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"fmt"
 	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // TransportType defines the communication method for MCP servers.
@@ -37,6 +39,8 @@ type ClientConfig struct {
 	Endpoint string
 	// Headers are custom HTTP headers to include in requests
 	Headers map[string]string
+	// SendingMiddleware intercepts outgoing MCP requests and notifications.
+	SendingMiddleware []sdkmcp.Middleware
 	// Timeout is the request timeout duration
 	Timeout time.Duration
 }


### PR DESCRIPTION
## Motivation

Applications using the MCP resolver sometimes need per-request behavior such as attaching tenant or caller metadata, propagating trace context, or recording protocol-level audit information. Static HTTP headers cannot represent concurrent calls that share one MCP client, and adding those values to tool arguments exposes transport metadata to the model and changes the tool schema.

The official Go MCP SDK already provides sending middleware for this purpose, but the Blades MCP wrapper did not expose it.

## Changes

- add `ClientConfig.SendingMiddleware`
- register configured middleware on the official MCP client before connecting
- add a Streamable HTTP integration test proving context-derived `_meta` reaches the MCP server
- document dynamic request metadata with a namespaced `_meta` example

The middleware is method-agnostic, so it works for any outgoing MCP request or notification and remains useful as the wrapper adds resources, prompts, and other protocol features. Existing configurations are unchanged when the field is empty.

## Verification

- `go test -race ./...` in `contrib/mcp`
- `go vet ./...` in `contrib/mcp`
