### PR TITLE
refactor(agent): align turns with model calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ provider := openai.NewChat("gpt-5",
 
 Tool concurrency is driven by model output. If a provider returns multiple `content.ToolUse` parts in one assistant message, the Agent loop executes that tool wave concurrently. To request at most one tool call per turn, configure the provider, for example `openai.WithParallelToolCalls(false)` or `anthropic.WithParallelToolCalls(false)`.
 
-Each turn corresponds to exactly one primary `Provider.Stream` call and its optional tool wave. Every completed response emits a mandatory `event.AssistantMessageEnd` with call-local usage. With tools, the order is all `ToolEnd` events, then `AssistantMessageEnd`, then `TurnEnd`; without tools, it is `AssistantMessageEnd`, then `TurnEnd`.
+Each turn corresponds to exactly one primary `Provider.Stream` call and its optional tool wave. Every response accepted by `AfterModel` emits a mandatory `event.AssistantMessageEnd` with call-local usage. With tools, the order is all `ToolEnd` events, then `AssistantMessageEnd`, then `TurnEnd`; without tools, it is `AssistantMessageEnd`, then `TurnEnd`.
 
 ## Tools And Agents
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The framework is designed for applications that need LLM agents as normal Go com
 
 ## Why Blades
 
-- **Event-first runtime**: applications interact with Agents through `event.Input` and `event.Output`, including streaming text, tool lifecycle events, turn endings, errors, and `Done`.
+- **Event-first runtime**: applications interact with Agents through `event.Input` and `event.Output`, including streaming text, tool lifecycle events, call-local assistant endings, turn endings, errors, and `Done`.
 - **Provider-neutral core**: OpenAI, Anthropic, Gemini, MCP, and observability integrations live in `contrib/`; the root module does not depend on provider SDKs.
 - **Multimodal protocol**: `content.Part` is the shared content union used by events, model messages, and tool results.
 - **Tool-ready Agent loop**: tools are described by `tools.ToolSpec`, executed by `tools.Tool`, filtered by policy, observed by hooks, and committed back into session history.
@@ -96,7 +96,7 @@ type Agent interface {
 | Package | Purpose |
 | --- | --- |
 | `content/` | Shared multimodal `Part` union for text, blobs, thinking, tool use, and tool results. |
-| `event/` | User-facing input and output events for prompts, steering, aborts, streaming, tools, turn endings, errors, and completion. |
+| `event/` | User-facing input and output events for prompts, steering, aborts, streaming, tools, assistant response endings, turn endings, errors, and completion. |
 | `model/` | Provider-facing requests, messages, chunks, responses, usage, options, and the `model.Provider` interface. |
 | `tools/` | Tool specs, execution interface, resolver/filter helpers, and tool context. |
 | `session/` | Append-only model message history and context helpers. |
@@ -129,6 +129,8 @@ provider := openai.NewChat("gpt-5",
 ```
 
 Tool concurrency is driven by model output. If a provider returns multiple `content.ToolUse` parts in one assistant message, the Agent loop executes that tool wave concurrently. To request at most one tool call per turn, configure the provider, for example `openai.WithParallelToolCalls(false)` or `anthropic.WithParallelToolCalls(false)`.
+
+Each turn corresponds to exactly one primary `Provider.Stream` call and its optional tool wave. Every completed response emits a mandatory `event.AssistantMessageEnd` with call-local usage. With tools, the order is all `ToolEnd` events, then `AssistantMessageEnd`, then `TurnEnd`; without tools, it is `AssistantMessageEnd`, then `TurnEnd`.
 
 ## Tools And Agents
 
@@ -166,6 +168,8 @@ for e := range out {
     switch v := e.(type) {
     case event.TextDelta:
         fmt.Print(v.Text)
+    case event.AssistantMessageEnd:
+        log.Printf("call usage: %+v", v.Usage)
     case event.Error:
         return v.Err
     }

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,7 +15,7 @@ Blades 适合把 LLM Agent 当作普通 Go 组件嵌入应用：输入输出显�
 
 ## 为什么选择 Blades
 
-- **事件优先的运行时**：应用通过 `event.Input` 和 `event.Output` 与 Agent 交互，覆盖流式文本、工具生命周期、turn 结束、错误和 `Done` 等事件。
+- **事件优先的运行时**：应用通过 `event.Input` 和 `event.Output` 与 Agent 交互，覆盖流式文本、工具生命周期、call-local assistant 结束、turn 结束、错误和 `Done` 等事件。
 - **Provider 无关的核心**：OpenAI、Anthropic、Gemini、MCP 和可观测集成都放在 `contrib/`，根模块不依赖任何模型厂商 SDK。
 - **统一多模态协议**：`content.Part` 是 Event、模型消息和工具结果共享的内容 union。
 - **内置工具循环**：工具由 `tools.ToolSpec` 描述、由 `tools.Tool` 执行，可经过 policy 校验、hook 观测，并写回 session 历史。
@@ -96,7 +96,7 @@ type Agent interface {
 | 包 | 职责 |
 | --- | --- |
 | `content/` | 共享的多模态 `Part` union，覆盖 text、blob、thinking、tool use 和 tool result。 |
-| `event/` | 面向用户和应用层的输入输出事件，覆盖 prompt、steer、abort、streaming、tool、turn end、error 和 done。 |
+| `event/` | 面向用户和应用层的输入输出事件，覆盖 prompt、steer、abort、streaming、tool、assistant response end、turn end、error 和 done。 |
 | `model/` | 面向 Provider 的 request、message、chunk、response、usage、option 和 `model.Provider` 接口。 |
 | `tools/` | 工具 spec、执行接口、resolver/filter 辅助能力和 tool context。 |
 | `session/` | append-only 模型消息历史和 context helper。 |
@@ -129,6 +129,8 @@ provider := openai.NewChat("gpt-5",
 ```
 
 工具并发由模型输出驱动。如果 Provider 在同一个 assistant message 中返回多个 `content.ToolUse`，Agent loop 会并发执行这一批 tool wave。若希望模型每轮最多返回一个工具调用，可在 Provider 上配置，例如 `openai.WithParallelToolCalls(false)` 或 `anthropic.WithParallelToolCalls(false)`。
+
+每个 turn 精确对应一次 primary `Provider.Stream` 调用及其可选 tool wave。每个完整响应都强制输出携带 call-local usage 的 `event.AssistantMessageEnd`。有工具时顺序固定为全部 `ToolEnd` → `AssistantMessageEnd` → `TurnEnd`；无工具时为 `AssistantMessageEnd` → `TurnEnd`。
 
 ## 工具与 Agent
 
@@ -166,6 +168,8 @@ for e := range out {
     switch v := e.(type) {
     case event.TextDelta:
         fmt.Print(v.Text)
+    case event.AssistantMessageEnd:
+        log.Printf("本次调用 usage: %+v", v.Usage)
     case event.Error:
         return v.Err
     }

--- a/agent.go
+++ b/agent.go
@@ -2,6 +2,7 @@ package blades
 
 import (
 	"context"
+	"slices"
 
 	"github.com/go-kratos/blades/compact"
 	"github.com/go-kratos/blades/event"
@@ -30,20 +31,19 @@ type Schemaer interface {
 
 // llmAgent is the default Agent implementation backed by an LLM provider.
 type llmAgent struct {
-	name                    string
-	description             string
-	inputSchema             *jsonschema.Schema
-	outputSchema            *jsonschema.Schema
-	hooks                   []hook.Hook
-	tools                   []tools.Tool
-	resolver                tools.Resolver
-	provider                model.Provider
-	promptBuilders          []prompt.Builder
-	compactor               compact.Compactor
-	contextWindow           model.ContextWindow
-	tokenCounter            model.TokenCounter
-	policy                  policy.Policy
-	sendAssistantMessageEnd bool
+	name           string
+	description    string
+	inputSchema    *jsonschema.Schema
+	outputSchema   *jsonschema.Schema
+	hooks          []hook.Hook
+	tools          []tools.Tool
+	resolver       tools.Resolver
+	provider       model.Provider
+	promptBuilders []prompt.Builder
+	compactor      compact.Compactor
+	contextWindow  model.ContextWindow
+	tokenCounter   model.TokenCounter
+	policy         policy.Policy
 }
 
 // NewAgent creates a new default LLM-backed Agent.
@@ -111,8 +111,8 @@ func (a *llmAgent) resolveTools(ctx context.Context) ([]tools.Tool, error) {
 
 func (a *llmAgent) clone() *llmAgent {
 	fork := *a
-	fork.hooks = append([]hook.Hook(nil), a.hooks...)
-	fork.tools = append([]tools.Tool(nil), a.tools...)
-	fork.promptBuilders = append([]prompt.Builder(nil), a.promptBuilders...)
+	fork.hooks = slices.Clone(a.hooks)
+	fork.tools = slices.Clone(a.tools)
+	fork.promptBuilders = slices.Clone(a.promptBuilders)
 	return &fork
 }

--- a/agent_loop.go
+++ b/agent_loop.go
@@ -184,10 +184,6 @@ func (l *agentLoop) runTurn(in turnInput) (turnOutcome, error) {
 
 	resp, err := l.runModelCall()
 	if err != nil {
-		if resp != nil {
-			state.recordResponse(resp)
-			l.emitAssistantMessageEnd(resp)
-		}
 		if hook.IsAbort(err) {
 			state.abort()
 		}
@@ -363,7 +359,7 @@ func (l *agentLoop) runModelCall() (*model.Response, error) {
 
 	for _, h := range l.agent.hooks {
 		if err := h.AfterModel(l.ctx, req, resp, nil); err != nil {
-			return resp, err
+			return nil, err
 		}
 	}
 

--- a/agent_loop.go
+++ b/agent_loop.go
@@ -26,7 +26,7 @@ type agentLoop struct {
 	turnNum int
 }
 
-// inputQueue separates current-turn steering from follow-up prompts.
+// inputQueue separates next-turn steering from follow-up prompts.
 type inputQueue struct {
 	ctx       context.Context
 	input     <-chan event.Input
@@ -34,14 +34,24 @@ type inputQueue struct {
 	closed    bool
 }
 
-type stepBoundaryInputs struct {
+type turnBoundaryInputs struct {
 	steering []event.Steer
 	aborted  bool
 }
 
-type stepBoundaryResult struct {
-	hasSteering bool
-	aborted     bool
+type turnBoundaryResult struct {
+	steering event.Input
+	aborted  bool
+}
+
+type turnInput struct {
+	input event.Input
+	merge bool
+}
+
+type turnOutcome struct {
+	continueNext bool
+	nextInput    turnInput
 }
 
 type toolWaveResult struct {
@@ -56,7 +66,7 @@ func (l *agentLoop) run() {
 	}()
 
 	for {
-		in, ok, err := l.inputs.nextTurnStart()
+		in, ok, err := l.inputs.nextInteractionStart()
 		if err != nil {
 			l.output <- event.Error{Err: err}
 			return
@@ -64,7 +74,7 @@ func (l *agentLoop) run() {
 		if !ok {
 			return
 		}
-		if err := l.runTurn(in); err != nil {
+		if err := l.runInteraction(in); err != nil {
 			l.output <- event.Error{Err: err}
 			return
 		}
@@ -75,7 +85,7 @@ func newInputQueue(ctx context.Context, input <-chan event.Input) *inputQueue {
 	return &inputQueue{ctx: ctx, input: input}
 }
 
-func (q *inputQueue) nextTurnStart() (event.Input, bool, error) {
+func (q *inputQueue) nextInteractionStart() (event.Input, bool, error) {
 	for {
 		if prompt, ok := q.popFollowUp(); ok {
 			return prompt, true, nil
@@ -102,8 +112,8 @@ func (q *inputQueue) nextTurnStart() (event.Input, bool, error) {
 	}
 }
 
-func (q *inputQueue) drainStepBoundaryInputs() (stepBoundaryInputs, error) {
-	var drained stepBoundaryInputs
+func (q *inputQueue) drainTurnBoundaryInputs() (turnBoundaryInputs, error) {
+	var drained turnBoundaryInputs
 	for {
 		if q.closed {
 			return drained, nil
@@ -111,7 +121,7 @@ func (q *inputQueue) drainStepBoundaryInputs() (stepBoundaryInputs, error) {
 
 		select {
 		case <-q.ctx.Done():
-			return stepBoundaryInputs{}, q.ctx.Err()
+			return turnBoundaryInputs{}, q.ctx.Err()
 		case in, ok := <-q.input:
 			if !ok {
 				q.closed = true
@@ -141,47 +151,134 @@ func (q *inputQueue) popFollowUp() (event.Prompt, bool) {
 	return in, true
 }
 
-func (l *agentLoop) runTurn(in event.Input) error {
+func (l *agentLoop) runInteraction(in event.Input) error {
+	next := turnInput{input: in}
+	for {
+		outcome, err := l.runTurn(next)
+		if err != nil {
+			return err
+		}
+		if !outcome.continueNext {
+			return nil
+		}
+		next = outcome.nextInput
+	}
+}
+
+func (l *agentLoop) runTurn(in turnInput) (turnOutcome, error) {
 	l.turnNum++
-	turn := &hook.Turn{AgentName: l.agent.name, Turn: l.turnNum, Input: in}
+	turn := &hook.Turn{AgentName: l.agent.name, Turn: l.turnNum, Input: in.input}
 	state := newTurnState()
 
 	if err := l.beforeTurn(turn); err != nil {
 		state.abort()
 		l.endTurn(turn, state, err)
-		return abortAsNil(err)
+		return turnOutcome{}, abortAsNil(err)
 	}
 
-	msg, ok := inputToMessage(turn.Input)
-	if !ok {
-		err := fmt.Errorf("agent loop: unsupported turn input %T", turn.Input)
+	if err := l.appendTurnInput(turn.Input, in.merge); err != nil {
 		state.abort()
 		l.endTurn(turn, state, err)
-		return err
+		return turnOutcome{}, err
 	}
-	if err := l.sess.Append(l.ctx, msg); err != nil {
-		state.abort()
+
+	resp, err := l.runModelCall()
+	if err != nil {
+		if resp != nil {
+			state.recordResponse(resp)
+			l.emitAssistantMessageEnd(resp)
+		}
+		if hook.IsAbort(err) {
+			state.abort()
+		}
 		l.endTurn(turn, state, err)
-		return err
+		return turnOutcome{}, abortAsNil(err)
+	}
+	state.recordResponse(resp)
+
+	toolUses := execute.ExtractToolUses(resp.Message)
+	if len(toolUses) > 0 {
+		return l.finishToolTurn(
+			turn,
+			&state,
+			resp,
+			toolUses,
+		)
 	}
 
-	for {
-		cont, err := l.runTurnStep(&state)
-		if err != nil {
-			if hook.IsAbort(err) {
-				state.abort()
-			}
-			l.endTurn(turn, state, err)
-			return abortAsNil(err)
+	return l.finishModelTurn(turn, &state, resp)
+}
+
+func (l *agentLoop) finishToolTurn(
+	turn *hook.Turn,
+	state *turnState,
+	resp *model.Response,
+	toolUses []content.ToolUse,
+) (turnOutcome, error) {
+	toolMsg, action, err := l.executeToolWave(toolUses)
+	l.emitAssistantMessageEnd(resp)
+	if err != nil {
+		if hook.IsAbort(err) {
+			state.abort()
 		}
-		if cont {
-			continue
-		}
-		break
+		l.endTurn(turn, *state, err)
+		return turnOutcome{}, abortAsNil(err)
+	}
+	if err := l.sess.Append(l.ctx, resp.Message, toolMsg); err != nil {
+		l.endTurn(turn, *state, err)
+		return turnOutcome{}, err
+	}
+	if action != nil {
+		state.stopForAction(action)
+		l.endTurn(turn, *state, nil)
+		return turnOutcome{}, nil
 	}
 
-	l.endTurn(turn, state, nil)
-	return nil
+	boundary, err := l.consumeTurnBoundaryInputs(state)
+	if err != nil {
+		l.endTurn(turn, *state, err)
+		return turnOutcome{}, err
+	}
+	l.endTurn(turn, *state, nil)
+	if boundary.aborted {
+		return turnOutcome{}, nil
+	}
+	return turnOutcome{
+		continueNext: true,
+		nextInput: turnInput{
+			input: boundary.steering,
+			merge: boundary.steering != nil,
+		},
+	}, nil
+}
+
+func (l *agentLoop) finishModelTurn(
+	turn *hook.Turn,
+	state *turnState,
+	resp *model.Response,
+) (turnOutcome, error) {
+	l.emitAssistantMessageEnd(resp)
+	if err := l.sess.Append(l.ctx, resp.Message); err != nil {
+		l.endTurn(turn, *state, err)
+		return turnOutcome{}, err
+	}
+
+	boundary, err := l.consumeTurnBoundaryInputs(state)
+	if err != nil {
+		l.endTurn(turn, *state, err)
+		return turnOutcome{}, err
+	}
+	l.endTurn(turn, *state, nil)
+	if boundary.aborted || boundary.steering == nil {
+		return turnOutcome{}, nil
+	}
+	return turnOutcome{
+		continueNext: true,
+		nextInput: turnInput{
+			input: boundary.steering,
+			merge: true,
+		},
+	}, nil
 }
 
 func abortAsNil(err error) error {
@@ -191,56 +288,26 @@ func abortAsNil(err error) error {
 	return err
 }
 
-func (l *agentLoop) runTurnStep(state *turnState) (bool, error) {
-	resp, err := l.runStep()
-	if err != nil {
-		return false, err
+func (l *agentLoop) appendTurnInput(in event.Input, merge bool) error {
+	if in == nil {
+		return nil
 	}
-	state.recordResponse(resp)
-	if l.agent.sendAssistantMessageEnd {
-		l.output <- convert.ResponseToAssistantMessageEnd(resp)
+	if merge {
+		steer, ok := in.(event.Steer)
+		if !ok {
+			return fmt.Errorf("agent loop: unsupported merged turn input %T", in)
+		}
+		return l.sess.AppendUser(l.ctx, steer.Parts...)
 	}
-
-	toolUses := execute.ExtractToolUses(resp.Message)
-	if len(toolUses) > 0 {
-		return l.handleToolStep(state, resp.Message, toolUses)
+	msg, ok := inputToMessage(in)
+	if !ok {
+		return fmt.Errorf("agent loop: unsupported turn input %T", in)
 	}
-
-	if err := l.commitStep(resp.Message); err != nil {
-		return false, err
-	}
-	state.finish(resp.StopReason)
-	return l.continueAfterModelStep(state)
+	return l.sess.Append(l.ctx, msg)
 }
 
-func (l *agentLoop) handleToolStep(state *turnState, assistantMsg *model.Message, toolUses []content.ToolUse) (bool, error) {
-	toolMsg, action, err := l.executeToolWave(toolUses)
-	if err != nil {
-		return false, err
-	}
-	if err := l.commitStep(assistantMsg, toolMsg); err != nil {
-		return false, err
-	}
-	if action != nil {
-		state.stopForAction(action)
-		return false, nil
-	}
-	inputs, err := l.consumeStepBoundaryInputs(state)
-	if err != nil {
-		return false, err
-	}
-	return !inputs.aborted, nil
-}
-
-func (l *agentLoop) continueAfterModelStep(state *turnState) (bool, error) {
-	inputs, err := l.consumeStepBoundaryInputs(state)
-	if err != nil {
-		return false, err
-	}
-	if inputs.aborted {
-		return false, nil
-	}
-	return inputs.hasSteering, nil
+func (l *agentLoop) emitAssistantMessageEnd(resp *model.Response) {
+	l.output <- convert.ResponseToAssistantMessageEnd(resp)
 }
 
 func (l *agentLoop) beforeTurn(turn *hook.Turn) error {
@@ -264,14 +331,17 @@ func (l *agentLoop) endTurn(turn *hook.Turn, result turnState, err error) {
 	summary := &hook.TurnSummary{
 		Parts:      result.parts,
 		StopReason: model.StopReason(result.stopReason),
-		Usage:      &model.Usage{InputTokens: result.usage.InputTokens, OutputTokens: result.usage.OutputTokens},
+		Usage: &model.Usage{
+			InputTokens:  result.usage.InputTokens,
+			OutputTokens: result.usage.OutputTokens,
+		},
 	}
 	for _, h := range l.agent.hooks {
 		_ = h.AfterTurn(l.ctx, turn, summary, err)
 	}
 }
 
-func (l *agentLoop) runStep() (*model.Response, error) {
+func (l *agentLoop) runModelCall() (*model.Response, error) {
 	req, err := l.buildRequest(l.ctx)
 	if err != nil {
 		return nil, err
@@ -283,7 +353,7 @@ func (l *agentLoop) runStep() (*model.Response, error) {
 		}
 	}
 
-	resp, err := l.streamStep(l.ctx, req)
+	resp, err := l.streamModelCall(l.ctx, req)
 	if err != nil {
 		for _, h := range l.agent.hooks {
 			_ = h.AfterModel(l.ctx, req, nil, err)
@@ -293,7 +363,7 @@ func (l *agentLoop) runStep() (*model.Response, error) {
 
 	for _, h := range l.agent.hooks {
 		if err := h.AfterModel(l.ctx, req, resp, nil); err != nil {
-			return nil, err
+			return resp, err
 		}
 	}
 
@@ -308,7 +378,7 @@ func (l *agentLoop) buildRequest(ctx context.Context) (*model.Request, error) {
 	}.Build(ctx)
 }
 
-func (l *agentLoop) streamStep(ctx context.Context, req *model.Request) (*model.Response, error) {
+func (l *agentLoop) streamModelCall(ctx context.Context, req *model.Request) (*model.Response, error) {
 	var (
 		parts      []content.Part
 		stopReason model.StopReason
@@ -322,8 +392,8 @@ func (l *agentLoop) streamStep(ctx context.Context, req *model.Request) (*model.
 		if chunk == nil {
 			continue
 		}
-		for _, o := range convert.ChunkToOutputs(chunk) {
-			l.output <- o
+		for _, eventOutput := range convert.ChunkToOutputs(chunk) {
+			l.output <- eventOutput
 		}
 		parts = append(parts, chunk.Parts...)
 		if chunk.StopReason != "" {
@@ -420,7 +490,11 @@ func (l *agentLoop) runToolCalls(runtime execute.Runtime, calls []content.ToolUs
 	return results, nil
 }
 
-func (l *agentLoop) finalizeToolResult(runtime execute.Runtime, call content.ToolUse, execResult execute.Result) (execute.Result, error) {
+func (l *agentLoop) finalizeToolResult(
+	runtime execute.Runtime,
+	call content.ToolUse,
+	execResult execute.Result,
+) (execute.Result, error) {
 	result := &tools.Result{Parts: execResult.Parts}
 	hookCall := &hook.ToolCall{
 		ID:        call.ID,
@@ -439,42 +513,33 @@ func (l *agentLoop) finalizeToolResult(runtime execute.Runtime, call content.Too
 }
 
 func (l *agentLoop) emitToolEnd(result execute.Result) {
-	l.output <- event.ToolEnd{ID: result.ID, Name: result.Name, Parts: result.Parts, IsError: result.IsError}
+	l.output <- event.ToolEnd{
+		ID:      result.ID,
+		Name:    result.Name,
+		Parts:   result.Parts,
+		IsError: result.IsError,
+	}
 }
 
-func (l *agentLoop) commitStep(msgs ...*model.Message) error {
-	filtered := make([]*model.Message, 0, len(msgs))
-	for _, msg := range msgs {
-		if msg != nil {
-			filtered = append(filtered, msg)
-		}
-	}
-	if len(filtered) == 0 {
-		return nil
-	}
-	return l.sess.Append(l.ctx, filtered...)
-}
-
-func (l *agentLoop) consumeStepBoundaryInputs(state *turnState) (stepBoundaryResult, error) {
-	drained, err := l.inputs.drainStepBoundaryInputs()
+func (l *agentLoop) consumeTurnBoundaryInputs(state *turnState) (turnBoundaryResult, error) {
+	drained, err := l.inputs.drainTurnBoundaryInputs()
 	if err != nil {
-		return stepBoundaryResult{}, err
+		return turnBoundaryResult{}, err
 	}
-	if len(drained.steering) > 0 {
-		parts := make([]content.Part, 0, len(drained.steering))
-		for _, steer := range drained.steering {
-			parts = append(parts, steer.Parts...)
-		}
-		if err := l.sess.AppendUser(l.ctx, parts...); err != nil {
-			return stepBoundaryResult{}, err
-		}
+	parts := make([]content.Part, 0, len(drained.steering))
+	for _, steer := range drained.steering {
+		parts = append(parts, steer.Parts...)
 	}
 	if drained.aborted {
 		state.abort()
 	}
-	return stepBoundaryResult{
-		hasSteering: len(drained.steering) > 0,
-		aborted:     drained.aborted,
+	var steering event.Input
+	if len(drained.steering) > 0 {
+		steering = event.Steer{Parts: parts}
+	}
+	return turnBoundaryResult{
+		steering: steering,
+		aborted:  drained.aborted,
 	}, nil
 }
 

--- a/agent_loop.go
+++ b/agent_loop.go
@@ -59,6 +59,25 @@ type toolWaveResult struct {
 	result execute.Result
 }
 
+// run drives the outer interaction loop:
+//
+//	run
+//	 |
+//	 v
+//	nextInteractionStart
+//	 |
+//	 | Prompt or idle Steer
+//	 v
+//	runInteraction
+//	 |
+//	 +--> runTurn: model call -> optional tool wave -> TurnEnd
+//	 |                                      |
+//	 +<-------------------------------------+
+//	          tool result or active Steer starts the next turn
+//
+// A Prompt received during an active interaction is queued for the next
+// interaction. Abort ends the current interaction. Each runTurn contains
+// exactly one primary model call and its resulting tool wave.
 func (l *agentLoop) run() {
 	defer func() {
 		l.output <- event.Done{}

--- a/agent_state.go
+++ b/agent_state.go
@@ -18,19 +18,16 @@ func newTurnState() turnState {
 }
 
 func (s *turnState) recordResponse(resp *model.Response) {
-	s.usage.InputTokens += resp.Usage.InputTokens
-	s.usage.OutputTokens += resp.Usage.OutputTokens
-	if resp.Message != nil {
-		s.parts = resp.Message.Parts
+	s.usage = event.Usage{
+		InputTokens:  resp.Usage.InputTokens,
+		OutputTokens: resp.Usage.OutputTokens,
 	}
+	s.parts = resp.Message.Parts
+	s.stopReason = outputStopReason(resp.StopReason)
 }
 
 func (s *turnState) abort() {
 	s.stopReason = event.StopAbort
-}
-
-func (s *turnState) finish(reason model.StopReason) {
-	s.stopReason = outputStopReason(reason)
 }
 
 func (s *turnState) stopForAction(action event.Action) {

--- a/contrib/anthropic/README.md
+++ b/contrib/anthropic/README.md
@@ -48,7 +48,7 @@ When used through `blades.NewAgent`, the Agent Loop handles this cycle:
 2. collect `content.ToolUse` parts from the assistant message;
 3. execute the returned tool wave concurrently;
 4. append ordered `content.ToolResult` parts to the session;
-5. continue with the next model step.
+5. end the current turn and continue with the next turn/model call.
 
 `WithParallelToolCalls(false)` maps to Claude `tool_choice.auto.disable_parallel_tool_use=true`. The Agent Loop does not inspect this option; it executes the tool wave returned by the model.
 

--- a/contrib/gemini/README.md
+++ b/contrib/gemini/README.md
@@ -63,4 +63,4 @@ for chunk, err := range provider.Stream(ctx, req) {
 
 Tool schemas are supplied on `model.Request.Tools`. Gemini function calls are converted to `content.ToolUse`, and function responses are represented as `content.ToolResult` in a `model.RoleTool` message.
 
-When used through `blades.NewAgent`, the Agent Loop owns tool execution, session commit, and follow-up model steps.
+When used through `blades.NewAgent`, the Agent Loop owns tool execution, session commit, and follow-up turns. Each turn corresponds to one primary model call.

--- a/docs/design-agent-framework.md
+++ b/docs/design-agent-framework.md
@@ -56,7 +56,7 @@ type Agent interface {
 
 `event/` 是 Event 协议的唯一用户入口。根包不 re-export `event.Input`、`event.Output`，也不提供 `Prompt`、`Steer`、`Abort` 这类 Event 构造函数。事件中的多模态字段直接使用 `content.Part`。这样用户只需要理解一个 Event 包，避免同一类型同时出现在 `blades` 和 `event` 两个命名空间。
 
-`blades.NewAgent(name, opts...)` 返回默认 `llmAgent`。`llmAgent` 在根包内部实现 follow-up loop / step loop / tool wave 运行模型；用户不需要导入公开 `loop/` 包。通过 `WithHooks`、`WithPolicy`、`WithCompact`、`WithPrompt` 等 options 注入扩展能力；完全不同的 runtime 直接实现 `blades.Agent`。
+`blades.NewAgent(name, opts...)` 返回默认 `llmAgent`。`llmAgent` 在根包内部实现 interaction loop / per-call turn / tool wave 运行模型；用户不需要导入公开 `loop/` 包。通过 `WithHooks`、`WithPolicy`、`WithCompact`、`WithPrompt` 等 options 注入扩展能力；完全不同的 runtime 直接实现 `blades.Agent`。
 
 `event/` 构造函数提供多模态变参便利：`event.NewPrompt(parts ...any) Prompt` / `event.NewSteer(parts ...any) Steer` 接受 `string`（自动包装为 `content.Text`）以及任意 `content.Part` 实现，无需独立事件类型。
 
@@ -74,10 +74,12 @@ for out := range output {
     switch e := out.(type) {
     case event.TextDelta:
         // e.Text is the streamed text delta
+    case event.AssistantMessageEnd:
+        // one completed LLM response, with call-local usage
     case event.Error:
         return e.Err
     case event.TurnEnd:
-        // one model turn ended
+        // one model call and its tool wave ended
     case event.Done:
         // agent lifecycle ended
     }
@@ -120,7 +122,8 @@ type Input  interface{ input()  }
 type Output interface{ output() }
 
 // 多模态字段使用 content.Part。
-// 例如：event.Prompt.Parts、event.TurnEnd.Parts、event.ToolEnd.Parts
+// 例如：event.Prompt.Parts、event.AssistantMessageEnd.Parts、
+// event.TurnEnd.Parts、event.ToolEnd.Parts
 // 字段类型就是 content.Part / []content.Part。
 ```
 
@@ -128,8 +131,8 @@ type Output interface{ output() }
 
 | 事件 | 用途 |
 |------|------|
-| `Prompt` | 用户或系统发起一个新 turn |
-| `Steer` | Agent 运行中注入修正、追加上下文或继续指令 |
+| `Prompt` | 用户或系统发起一个新 interaction |
+| `Steer` | Agent 运行中为下一个 turn 注入修正、追加上下文或继续指令 |
 | `Abort` / `Pause` / `Resume` | 三种独立 Control 类型；`Abort{Reason string}` 与 `context.Cancel` 互补承载终止原因 |
 
 输出事件：
@@ -138,7 +141,8 @@ type Output interface{ output() }
 |------|------|
 | `TextDelta` / `ThinkingDelta` | 文本和 thinking 的常用流式输出 |
 | `ToolStart` / `ToolDelta` / `ToolEnd` | 工具执行生命周期 |
-| `TurnEnd` | 单 turn 结束（含 `Parts []content.Part`、`StopReason`、token usage 汇总） |
+| `AssistantMessageEnd` | primary LLM response 完成；在其 tool wave 全部 `ToolEnd` 后输出，携带 call-local parts、stop reason 与 usage |
+| `TurnEnd` | 单 turn 结束；一个 turn 精确对应一次 primary model call 及其可选 tool wave，usage 不跨 call 汇总 |
 | `Error` | 运行期错误（实现 `Output`，与其他事件同流；`event.Error{Err error}` 用 Go 标准 error，靠 `errors.Is/As` + 包内 sentinel 判断；启动期错误走 `Run` 签名第二返回值） |
 | `Done` | Run 结束 sentinel；channel 关闭前发送，便于多 channel `select` 分支区分 |
 
@@ -149,7 +153,7 @@ type Output interface{ output() }
 
 `event` 中的多模态字段、`tools.Result.Parts`、`model.Message.Parts`、`model.Chunk.Parts` 全部直接使用 `content.Part`，三个协议包不再各自定义 Part。`content/` 不引入统一 `Metadata map[string]any`——业务扩展通过应用层嵌入业务结构体实现。
 
-文本和多模态输入都用 `event.NewPrompt(...)` / `event.NewSteer(...)` 构造函数返回 `Prompt` / `Steer`，可混合 string 与 `content.Part`（底层调用 `content.NewParts`）。流式文本/思考输出走紧凑值类型 `event.TextDelta` / `event.ThinkingDelta`（hot path，避免 interface boxing）。其他多模态 part 当前只出现在最终 `TurnEnd.Parts`、`ToolEnd.Parts` 和 Session message 中；Blob 流式生命周期事件留给后续公开协议升级。
+文本和多模态输入都用 `event.NewPrompt(...)` / `event.NewSteer(...)` 构造函数返回 `Prompt` / `Steer`，可混合 string 与 `content.Part`（底层调用 `content.NewParts`）。流式文本/思考输出走紧凑值类型 `event.TextDelta` / `event.ThinkingDelta`（hot path，避免 interface boxing）。其他多模态 part 当前只出现在最终 `AssistantMessageEnd.Parts`、`TurnEnd.Parts`、`ToolEnd.Parts` 和 Session message 中；Blob 流式生命周期事件留给后续公开协议升级。
 
 Agent Loop 在工具结果落点做轻量包装而非全 DTO 复制：`tools.Result{Parts: []content.Part}` → `event.ToolEnd.Parts` 直接复用同一切片，→ `model.Message.Parts` 中追加 `content.ToolResult{Parts: ...}` 同样直接复用。
 
@@ -174,7 +178,7 @@ Event 和 Message 不合并。原因：
 │    Agent / NewAgent / Option / Runner                             │
 ├─────────────────────────────────────────────────────────────────┤
 │  Execution Kernel                                                 │
-│    llmAgent 默认 follow-up loop / step loop / tool wave 执行循环    │
+│    llmAgent 默认 interaction / per-call turn / tool wave 执行循环  │
 │    flow/ 组合原语                                                   │
 ├─────────────────────────────────────────────────────────────────┤
 │  Extension Layer                                                  │
@@ -198,10 +202,11 @@ Event 和 Message 不合并。原因：
 | 多模态共享叶子 | `content/` 仅依赖标准库；`Part` 为 sealed marker（私有 `part()`）；变体 = Text/FilePart/FileRefPart/DataPart/Thinking/ToolUse/ToolResult；Thinking 含 Signature |
 | Provider 协议 sealed | 三处 sealed 例外全部封闭：`content.Part`（私有 `part()`）、`event.Input`（私有 `input()`）、`event.Output`（私有 `output()`）。核心协议层无开放扩展接口；后台回流走 `event.Prompt`，应用业务事件由应用自己的 channel / event bus 承载。`hook/` 不再使用 sealed event union，改为单 `Hook` 接口（6 个生命周期方法）+ `hook.Noop` 嵌入式默认实现（详见 `design-hook-extension.md`） |
 | ToolSpec 定义在 tools/ | `tools.ToolSpec` 是唯一定义点；`model.Request.Tools` 直接使用 `[]tools.ToolSpec`；`model/` 单向依赖 `tools/` |
-| Runtime 根包内置 | 默认 Agent Loop 是根包 `llmAgent` 的内部机制，不暴露公开 `loop/` 包；run/turn/step/tool wave 私有控制流集中在 `agent_loop.go` |
-| 无 maxSteps | Agent Loop 不设步数上限，靠 model stop reason（无 tool calls）+ `TurnEnd.Action` 工具控制信号（LoopExit/Handoff）+ ctx 取消 + Abort 事件终止循环 |
+| Runtime 根包内置 | 默认 Agent Loop 是根包 `llmAgent` 的内部机制，不暴露公开 `loop/` 包；run/interaction/turn/tool wave 私有控制流集中在 `agent_loop.go` |
+| Turn 与 call 1:1 | 每个 turn 恰好执行一次 primary `Provider.Stream`；工具续接和 active steering 都开启新 turn，call-local usage 不跨 turn 聚合 |
+| 无 maxTurns | Agent Loop 不设 turn 数上限，靠无 tool calls/steering + `TurnEnd.Action` 工具控制信号（LoopExit/Handoff）+ ctx 取消 + Abort 事件终止 interaction |
 | 唯一私有转换 | 仅 `internal/convert/` 持 Event ↔ Message 转换函数；用户不得绕过 Loop 直接转换 |
-| 不显式 FSM 枚举 | `llmAgent` 内部用 follow-up loop / step loop / tool wave 顺序代码 + 行为事件 hook 表达流程；不导出 `State` 枚举 |
+| 不显式 FSM 枚举 | `llmAgent` 内部用 interaction loop / turn / tool wave 顺序代码 + 行为事件 hook 表达流程；不导出 `State` 枚举 |
 | Context 三准则 | 入 ctx 的 capability 必须满足：runtime-scoped + Run 内不变 + 多层共需；否则下沉应用层 context key |
 | Context 命名统一 | `pkg.NewContext(ctx, x)` / `pkg.FromContext(ctx) (X, bool)` stdlib 风格；`session/tools` 两处 helper 同形 |
 | Policy 单边界 | `policy/` 单向依赖 `tools/`（不依赖 `event/model/content`）；v1 唯一请求是 `policy.ToolRequest{Tool tools.Tool, Input json.RawMessage}`；`Policy.Check(ctx, ToolRequest) Decision` 单方法接口；不引入模型请求/资源请求等 sealed union。模型预算与速率限制由 hook + 应用层组合实现 |
@@ -215,7 +220,7 @@ Event 和 Message 不合并。原因：
 ```
 blades/
 ├── agent.go                    Agent 接口 + NewAgent + llmAgent 字段与方法
-├── agent_loop.go               默认 LLM Agent 私有 loop：agentLoop/input queue/turn/step/tool wave/Session commit
+├── agent_loop.go               默认 LLM Agent 私有 loop：agentLoop/input queue/interaction/turn/tool wave/Session commit
 ├── context_window.go           ContextWindow + BudgetError + ctx helper
 ├── context_builder.go          默认 Agent 私有 request-view 装配：session + compact + prompt + tools + budget stats
 ├── option.go                   AgentOption + WithModel/WithTools/WithPolicy/WithHooks/WithCompact/WithContextBudget/WithTokenCounter/WithPrompt/WithDescription/WithToolsResolver
@@ -237,6 +242,7 @@ blades/
 │   ├── input.go                Prompt{Parts []content.Part}, Steer{Parts []content.Part}, NewPrompt/NewSteer 构造函数
 │   ├── stream.go               TextDelta/ThinkingDelta（hot path，紧凑值类型）
 │   ├── tool.go                 ToolStart{ID, Name, Input}, ToolDelta{ID, Data}, ToolEnd{ID, Name, Parts, IsError}
+│   ├── message.go              AssistantMessageEnd{Parts, StopReason, Usage}（mandatory call-local response event）
 │   └── terminal.go             TurnEnd{Parts, StopReason, Usage, Err, Action}, Error{Err}, Done{}；StopReason/Usage 类型
 │
 ├── model/
@@ -294,7 +300,7 @@ blades/
 │   └── inmemory.go             in-memory Memory 实现
 │
 ├── internal/
-│   └── convert/                Event ↔ Message 唯一私有转换（PromptToMessage / SteerToMessage / ToolResultToMessage / ChunkToOutputs / ResponseToTurnEnd）
+│   └── convert/                Event ↔ Message 唯一私有转换（PromptToMessage / SteerToMessage / ToolResultToMessage / ChunkToOutputs / ResponseToAssistantMessageEnd）
 └── contrib/                    provider/preset/observability 集成
 ```
 
@@ -351,7 +357,7 @@ run manager 语义（run ID、队列、daemon、cron、后台 job、主动通知
 
 容易混淆，明确区分：
 
-- **根包 `llmAgent`**：*单个* Agent 内部的运行循环（follow-up loop → step loop → tool wave）。无公开 `loop/` 包，`llmAgent` receiver 方法统一放在 `agent.go`，私有执行对象 `agentLoop` 的控制流集中在 `agent_loop.go`。
+- **根包 `llmAgent`**：*单个* Agent 内部的运行循环（interaction loop → per-call turn → tool wave）。无公开 `loop/` 包，`llmAgent` receiver 方法统一放在 `agent.go`，私有执行对象 `agentLoop` 的控制流集中在 `agent_loop.go`。
 - **`flow/`**：*多个* Agent 之间的组合（Sequential / Parallel / Loop / Routing / Deep）。`flow.NewLoopAgent` 是把另一个 Agent 反复调用，不是单 Agent 内部的 provider/tool 循环。
 - **根包 `blades.NewAgentTool`**：把一个 `blades.Agent` 暴露为 `tools.Tool`，让另一个 Agent 通过工具调用启用它；属于"Agent 是顶层 first-class 概念"语义，故落在根包 `tool.go` 而非 `flow/`。签名为 `NewAgentTool(agent Agent) tools.Tool`。
 
@@ -409,7 +415,7 @@ contrib/*   -> model/ 或 tools/
 |----|----------|------|
 | `blades` (root) | `Agent`, `RunningAgent`, `NewAgent`, `AgentOption`, `NewAgentTool`, `NewContext`/`FromContext`, `ContextWindow`, `BudgetError`, `ContextWindowFrom`, `Runner`/`Result`/`NewRunner`/`RunnerOption`（`Run`/`RunStream`/`RunLive`）, `WithModel`/`WithTools`/`WithToolsResolver`/`WithPolicy`/`WithHooks`/`WithCompact`/`WithContextBudget`/`WithTokenCounter`/`WithPrompt`/`WithDescription` | `blades.Agent` |
 | `content` | `Part`（sealed marker：私有 `part()`），`Text`，`TextFromParts`，`NewParts(inputs ...any) []Part`，`FilePart{URI, MIME, Filename}`，`FileRefPart{ID, MIME}`，`DataPart{Bytes, MIME, Filename}`，`Thinking{Text, Signature []byte}`，`ToolUse{ID, Name, Input}`，`ToolResult{ID, Name, Parts, IsError}` | `content.NewParts("hi", content.FilePart{...})` |
-| `event` | `Input`（sealed：`input()`）, `Output`（sealed：`output()`）, `Prompt`, `Steer`, `Abort{Reason}`, `Pause`, `Resume`, `TextDelta`, `ThinkingDelta`, `ToolStart`, `ToolDelta`, `ToolEnd`, `Action`, `LoopExit{Escalate}`, `Handoff{Agent}`, `TurnEnd`（含 `Text()`）, `Error`, `Done`, `StopReason`, `Usage`；构造糖：`NewPrompt`, `NewSteer` | `event.NewPrompt("hi", content.DataPart{...})` |
+| `event` | `Input`（sealed：`input()`）, `Output`（sealed：`output()`）, `Prompt`, `Steer`, `Abort{Reason}`, `Pause`, `Resume`, `TextDelta`, `ThinkingDelta`, `ToolStart`, `ToolDelta`, `ToolEnd`, `AssistantMessageEnd`（含 call-local `Usage`）, `Action`, `LoopExit{Escalate}`, `Handoff{Agent}`, `TurnEnd`（含 `Text()`）, `Error`, `Done`, `StopReason`, `Usage`；构造糖：`NewPrompt`, `NewSteer` | `event.NewPrompt("hi", content.DataPart{...})` |
 | `model` | `Message{Role, Parts []content.Part, Metadata MessageMetadata}`, `MessageMetadata{Provider, API, Model}`, `Role`, `RoleUser`/`RoleAssistant`/`RoleTool`, `Provider`(Name+Generate+Stream `iter.Seq2`), `TokenCounter`/`TokenCount`/`ApproxTokenCounter`, `EmbeddingProvider`, `Request{Model, System, Messages, Tools []tools.ToolSpec, Options}`, `Response{Message, StopReason, Usage}`, `Chunk{Parts, StopReason, Usage}`, `Option` sealed（`CacheHint`/`ReasoningEffort`/`ResponseFormat`/`Sampling`/`ParallelToolCalls`）, `Usage`, `StopReason`, `Collect`, `MergeOptions` | `model.Provider` |
 | `tools` | `Tool`(Spec+Handle 两方法), `ToolSpec{Name, Description, InputSchema, OutputSchema}`, `Result{Parts []content.Part}`, `Resolver`(List+Resolve), `ToolFilter`, `ToolContext`(ID+Spec), `NewContext`/`FromContext`, `ErrLoopExit`/`ErrHandoff` | `tools.Tool` |
 | `prompt` | `Builder`(接口), `Section`(函数类型), `Static`/`Dynamic`/`System`/`Memory` 工厂, `New` | `prompt.Builder` |
@@ -424,15 +430,16 @@ contrib/*   -> model/ 或 tools/
 
 ### Event 系统与 Agent Loop
 
-Event 是用户协议层，定义 `event.Input` / `event.Output`，多模态字段直接使用 `content.Part`。Event 不和 `model.Message` 共享 Go 类型，但通过 `content.Part` 实现"零样板模态共享"。Agent Loop 在根包默认 `llmAgent` 内部实现，使用 follow-up loop / step loop / tool wave 顺序代码 + 行为事件 hook 表达流程（不导出 FSM 状态枚举），负责：
+Event 是用户协议层，定义 `event.Input` / `event.Output`，多模态字段直接使用 `content.Part`。Event 不和 `model.Message` 共享 Go 类型，但通过 `content.Part` 实现"零样板模态共享"。Agent Loop 在根包默认 `llmAgent` 内部实现，使用 interaction loop / per-call turn / tool wave 顺序代码 + 行为事件 hook 表达流程（不导出 FSM 状态枚举），负责：
 
 - 把 `event.Prompt` / `event.Steer` 转成 `model.Message`（通过 `internal/convert`）。
 - 从 Session + `prompt.Builder` + ToolSpec + Compact 构建 `model.Request`。
 - 调用 `model.Provider.Stream`。
 - 把 `model.Chunk` 中的文本和 thinking part 转成 `event.TextDelta` / `event.ThinkingDelta`。
 - 执行 tool wave：`BeforeTool` 做源顺序预处理；随后 `event.ToolStart` 按源顺序发出，policy check + Handle 并发执行，`AfterTool` / `event.ToolEnd` 按完成顺序发出；最终 `content.ToolResult` 按 assistant 源顺序追加到 Session。若希望模型一次最多返回一个工具调用，在 provider 构造时关闭 parallel tool calls。
-- 每个 model step / tool wave 边界非阻塞 drain active input：`agent_loop.go` 的 input queue helper 只分类 channel 事件；`Steer` 由同一文件中的 turn commit 路径写入当前 turn 下一步，`Prompt` 排队为下一 turn 的 follow-up，`Abort` 结束当前 turn。
-- turn 闲置时 blocking wait follow-up：`Prompt` 或 idle `Steer` 开启新 turn；input close 正常结束 Run。
+- 在完整 tool wave 后发出 mandatory `AssistantMessageEnd`，让消费者取得本次 primary call 的 response 与 usage；随后发出同一 call 的 `TurnEnd`。
+- 每个 turn / tool wave 边界非阻塞 drain active input：`agent_loop.go` 的 input queue helper 只分类 channel 事件；`Steer` 由下一个 turn 的 commit 路径写入，`Prompt` 排队为下一个 interaction 的 follow-up，`Abort` 结束当前 interaction。
+- interaction 闲置时 blocking wait follow-up：`Prompt` 或 idle `Steer` 开启新 interaction；input close 正常结束 Run。
 
 唯一的 Event ↔ Message 转换函数留在 `internal/convert/`，用户不得绕过 Loop 直接调用。
 
@@ -442,7 +449,7 @@ Event 是用户协议层，定义 `event.Input` / `event.Output`，多模态字�
 
 Runtime 包括根包 `blades/` 与 `flow/`。
 
-`blades.NewAgent(name, opts...)` 创建默认 `llmAgent`。Agent 持有 model provider、tools、resolver、policy、hooks、compactor、prompt builder 等配置，全部通过 Option 注入。Memory 不在根 Agent 内置（由应用层通过 `prompt.Memory` section 注入）。**根包绑定默认 LLM Agent 执行语义**，loop/step/tool wave 私有控制流集中在 `agent_loop.go`；完全不同的 runtime 直接实现 `blades.Agent` 接口。
+`blades.NewAgent(name, opts...)` 创建默认 `llmAgent`。Agent 持有 model provider、tools、resolver、policy、hooks、compactor、prompt builder 等配置，全部通过 Option 注入。Memory 不在根 Agent 内置（由应用层通过 `prompt.Memory` section 注入）。**根包绑定默认 LLM Agent 执行语义**，interaction/turn/tool wave 私有控制流集中在 `agent_loop.go`；完全不同的 runtime 直接实现 `blades.Agent` 接口。
 
 `flow.NewSequentialAgent` / `NewParallelAgent` / `NewLoopAgent` / `NewRoutingAgent` / `NewDeepAgent` 接受对应的 `*Config` 并返回普通 `blades.Agent`：
 
@@ -498,12 +505,12 @@ v1 核心保留五个组合原语 + 一个 Agent→Tool 适配器：
 
 `session.Session` 面向 Agent Loop，提供消息历史的最小操作集（`ID/Metadata/State/SetState/Append/Messages` 6 方法 append-only），不存在 `Truncate / Replace / Checkpoint / Store` 概念。常用 fork 可由应用层用 `session.NewSession + session.WithMessages + session.WithMetadata` 组合；它不是接口的一部分。JSONL、SQLite、Redis 等持久化后端独立暴露自身 API，不在 `session/` 包内置。详见 [design-session.md](design-session.md)。
 
-`compact.Compactor` 是一个纯函数式接口 `Compact(ctx, compact.Request) ([]*Message, error)`。Loop 在每个 model step 构建 `*model.Request` 之前**无条件**调用一次 `Compact`，由 Compactor 自身决定短路（已在预算内零成本透传）或工作（增量摘要、窗口裁剪、tool result 截断）。Compactor 永不写回 Session；其滚动状态（如 summarize 的 offset / summary 内容）通过 `Session.State()` 私有 key（`__compact_summary_offset__` / `__compact_summary_content__`）持久化。详见 [design-compact.md](design-compact.md) §触发时机 与 [design-event-agent-loop.md](design-event-agent-loop.md) §9。
+`compact.Compactor` 是一个纯函数式接口 `Compact(ctx, compact.Request) ([]*Message, error)`。Loop 在每个 turn 构建唯一的 primary `*model.Request` 之前**无条件**调用一次 `Compact`，由 Compactor 自身决定短路（已在预算内零成本透传）或工作（增量摘要、窗口裁剪、tool result 截断）。Compactor 永不写回 Session；其滚动状态（如 summarize 的 offset / summary 内容）通过 `Session.State()` 私有 key（`__compact_summary_offset__` / `__compact_summary_content__`）持久化。Compactor 为摘要而直接调用 `Provider.Generate` 时属于内部实现调用，不产生 turn、`AssistantMessageEnd` 或 `TurnEnd`。详见 [design-compact.md](design-compact.md) §触发时机 与 [design-event-agent-loop.md](design-event-agent-loop.md) §9。
 
 **增量与迭代两个契约支撑"按需控制上下文大小"**：
 
 - **增量压缩**：Session append-only ⇒ 消息下标稳定 ⇒ Compactor 仅需在 `Session.State()` 中维护单调递增的 `offset` 即可区分"已压缩区"与"未压缩区"，每次只对 `msgs[offset:]` 中新增的部分做工作，不会重复对已折叠的历史调用摘要 LLM。详见 [design-compact.md](design-compact.md) §增量压缩契约、[design-session.md](design-session.md) §为什么 append-only 是增量压缩的前提。
-- **迭代压缩 + Hint 重试两层兜底**：单次 `Compact` 调用内部循环折叠批次直到 ① 满足预算 ② `offset` 抵达 `len(msgs) - KeepRecent` 无可压区 ③ 触发安全阀（Step 内）；provider 真实仍报 context-too-long 时由 Loop 透传 `HintShrink` 重试 1 次（Step 间），仍未严格下降则 fail-fast `event.Error`。两层正交不互相替代。详见 [design-compact.md](design-compact.md) §迭代压缩契约、[design-event-agent-loop.md](design-event-agent-loop.md) §上下文超长的两层兜底。
+- **迭代压缩不扩大 turn**：单次 `Compact` 调用内部循环折叠批次直到 ① 满足预算 ② `offset` 抵达 `len(msgs) - KeepRecent` 无可压区 ③ 触发安全阀；这些工作都发生在 primary call 之前。默认 Loop 不隐藏 provider-level context-too-long retry；自定义 runtime 使用 `HintShrink` retry 时，每次新的 `Provider.Stream` 尝试也必须开启新 turn。详见 [design-compact.md](design-compact.md) §迭代压缩契约、[design-event-agent-loop.md](design-event-agent-loop.md) §上下文超长与 retry 边界。
 
 `contextBuilder` 是 Session / Prompt / Compact 与 `*model.Request` 之间的装配逻辑，位于根包私有实现，按有序 pipeline 装配——**先 compact 再 prompt**：`snapshot ← session.Messages(ctx)`；`view ← compactor.Compact(ctx, compact.Request{Messages: snapshot, TokenCounter: counter})`；`systemParts ← prompt.Builder.Build(ctx)`（memory 召回在此发生）；最终 `*model.Request{System: prompt.JoinText(systemParts), Messages: view, Tools}`。`WithContextBudget` 配置 input/system/messages/tools 预算，`WithTokenCounter` 显式配置完整 request 计数；未配置时使用 `model.ApproxTokenCounter`，不从 provider 自动探测；根包把 `ContextInfo` 暴露给 prompt/memory 构建期，把 `ContextStats` 暴露给 model hooks/provider 调用期。Compactor 仅看 messages、prompt builder 仅看 system，二者互不感知。详见 [design-context-management.md](design-context-management.md)。
 

--- a/docs/design-agent-orchestration.md
+++ b/docs/design-agent-orchestration.md
@@ -107,7 +107,7 @@ for out := range output {
 }
 ```
 
-默认桥接策略只在 `event.TurnEnd` 后把本轮最终内容作为下一段的 `event.Prompt`，**不**默认转发 `ToolStart` / `ToolDelta` / `ToolEnd` 等工具生命周期事件——这些事件属于用户可见输出，不应隐式变成下游 prompt。其它桥接需求由调用方显式提供：
+默认桥接策略会消费完中间 Agent 的输出流，并把最后一个 `event.TurnEnd` 的内容作为下一段的 `event.Prompt`。一个 interaction 含多个 per-call turn 时，中间的 `TurnEnd` 不会提前启动下游；`AssistantMessageEnd`、`ToolStart` / `ToolDelta` / `ToolEnd` 等生命周期事件也不会隐式变成下游 prompt。其它桥接需求由调用方显式提供：
 
 ```go
 type Bridge interface {
@@ -195,6 +195,6 @@ DeepAgent 仍然是一个普通 `blades.Agent`，可以再被 Sequential/Paralle
 1. **统一 Agent 接口**：所有原语都遵循 `Run(ctx, <-chan event.Input) (<-chan event.Output, error)`；组合的结果仍是一个普通 `blades.Agent`，可以无限嵌套。
 2. **统一构造风格**：所有原语用 `NewXxxAgent(XxxConfig{...})`，方便未来在不破坏调用方的情况下增加字段。
 3. **只组合 channel，不读取 Message**：`flow/` 不感知 `model.Message`、provider、session；复杂编排先放到应用层或 `contrib/`，不要把工作流语义塞进 flow。
-4. **桥接显式化**：Sequential 默认只透传 `event.TurnEnd` 的最终内容，工具生命周期事件不默认变成下游 prompt；其它桥接策略由调用方显式提供。
+4. **桥接显式化**：Sequential 默认消费完整输出流并只透传最后一个 `event.TurnEnd` 的内容；call/tool 生命周期事件不默认变成下游 prompt，其它桥接策略由调用方显式提供。
 5. **来源信息靠 `Name()`**：Parallel/Routing 都不给事件加 wrapper，调用方通过子 Agent 名字与 trace/hook 还原来源。
 6. **范围克制**：`flow/` 只做组合；后台运行、workspace、preset、复杂编排都放到应用层或 `contrib/`，避免根包膨胀。

--- a/docs/design-compact.md
+++ b/docs/design-compact.md
@@ -191,17 +191,10 @@ for {
 2. **无可压缩区间**：`offset` 已抵达 `len(msgs) - KeepRecent`，最近 N 条不允许折叠；返回当前最佳视图，由 Loop 决定后续动作。
 3. **安全上限**：单次 `Compact` 调用内的折叠批次数达到内部上限（防御性，避免摘要 LLM 异常时陷入死循环）；建议默认 `maxFoldIterations = 8`，可由实现暴露选项调优。
 
-返回视图后两层兜底机制（与 [design-event-agent-loop.md](design-event-agent-loop.md) §HintShrink / §9 对齐）：
+返回视图后的边界（与 [design-event-agent-loop.md](design-event-agent-loop.md) §上下文超长与 retry 边界 对齐）：
 
-- **Step 内（Compactor 自身）**：上述循环；属于"step 内迭代折叠"。
-- **Step 间（Loop 透传 hint）**：若 provider 实际调用仍返回 context-too-long 错误，Loop 通过 `compact.WithHint(ctx, HintShrink)` 透传 hint 进入**同一 step 的第二次**请求构造。Compactor 在 hint 模式下应采取更激进的策略（例如降低 `KeepRecent`、启用更紧的 `ToolResultBudget`），并必须返回**严格单调下降**的视图（token 数严格小于上一次返回的视图）。最大重试次数默认 1 次；若返回视图未严格下降或仍超预算，Loop **fail-fast** 抛出 `event.Error` 并终止 turn。
-
-两层机制的职责边界：
-
-| 层级 | 触发主体 | 触发条件 | 期望效果 |
-|------|----------|----------|----------|
-| Step 内迭代 | Compactor 自身 | 当前视图超 `MaxTokens` 估算 | 在不调 provider 的前提下尽量逼近预算 |
-| Step 间 hint | Loop | provider 实际报 context-too-long | 在 Compactor 估算与 provider 真实账本之间补差 |
+- **Compactor 内部迭代**：上述循环在一次 `Compact` 调用内完成，属于当前 turn 的 request 构建阶段。
+- **Provider error**：当前默认 Loop 不在同一 turn 内隐藏 context-too-long retry；错误结束本 turn。`HintShrink` 保留给自定义 runtime 构建更激进且严格单调下降的 retry view。任何新的 primary `Provider.Stream` 尝试都必须属于新 turn。
 
 实现要点：
 
@@ -213,11 +206,11 @@ for {
 
 Compactor 的调用点位于 Agent Loop 的请求构造阶段，遵循**"Loop 无条件调用、Compactor 自适应"**契约：
 
-1. **Loop 无条件调用**：每个 model step 构建 `*model.Request` 之前，Loop 都调用一次 `compactor.Compact(ctx, compact.Request{Messages: snapshot, TokenCounter: counter})`（hint 通过 `compact.WithHint(ctx, ...)` 注入 ctx）。Loop 不再判断"是否到了该压缩的时机"。
+1. **Loop 无条件调用**：每个 turn 构建其唯一的 primary `*model.Request` 之前，Loop 都调用一次 `compactor.Compact(ctx, compact.Request{Messages: snapshot, TokenCounter: counter})`（hint 通过 `compact.WithHint(ctx, ...)` 注入 ctx）。Loop 不再判断"是否到了该压缩的时机"。
 2. **Compactor 自适应短路**：
    - `Window` / `ToolResultBudget` 等纯函数策略在已经低于预算时直接 `return msgs, nil` 零成本透传。
    - `Summarize` 等带状态策略读取 `Session.State()` 中的 rolling summary 键（`__compact_summary_offset__` / `__compact_summary_content__`），仅当未摘要部分增长跨过阈值时才调用 LLM；其余调用直接拼接已有摘要 + 增量原文返回。
-3. **provider 硬错误重试**：当 provider 返回 context-too-long 类错误后，Loop 用 hint 重新构造一次请求，并通过 `compact.WithHint(ctx, HintShrink)` 透传给 `compactor.Compact`，Compactor 必须返回**严格单调下降**的视图。最大重试次数默认 1 次；若仍未下降，Loop fail-fast 抛出 `event.Error` 并终止 turn。
+3. **provider 硬错误边界**：当前默认 Loop 不隐藏 context-too-long retry；错误结束本 turn。自定义 runtime 可以通过 `compact.WithHint(ctx, HintShrink)` 构建严格单调下降的 retry view，但新的 `Provider.Stream` 尝试必须开启新 turn。
 4. **应用层显式整理**：`/compact` 命令、TTL 触发等由应用层主动调用 `Compactor` 或 `Memory` API 完成，与 Loop 路径解耦。Compactor 自身只关心"按预算压"。
 5. **工具结果裁剪**：`compact.NewToolResultBudget(maxBytes)` 作为 Chain 中的一个阶段，统一受上述流程驱动，不需要在 Loop 中做特化分支。
 
@@ -225,7 +218,7 @@ Compactor 的调用点位于 Agent Loop 的请求构造阶段，遵循**"Loop �
 
 - compact 输出仅用于本次 `*model.Request.Messages`；
 - **不写回 Session**：Session 严格 view-only（参见 [design-session.md](design-session.md) §4）；Compactor 的 rolling state 通过 `Session.State()` 私有 key 持久化，与协议历史正交；
-- 下次 step 重新调用 compact，仍由 Compactor 自身决定是短路透传还是重新计算（Summarize 借助 rolling summary 复用，避免重复 LLM 调用）。
+- 下个 turn 重新调用 compact，仍由 Compactor 自身决定是短路透传还是重新计算（Summarize 借助 rolling summary 复用，避免重复 LLM 调用）。
 
 ## 与 Memory 的关系
 
@@ -274,7 +267,7 @@ Memory（`memory.Memory`，参见 [design-memory.md](design-memory.md)）和 Com
 
 推荐 metric / log：
 
-- `compact_triggered_total{reason=step|retry|explicit|tool}`
+- `compact_triggered_total{reason=turn|retry|explicit|tool}`
 - `compact_token_before` / `compact_token_after`（直方图）
 - `compact_summarize_latency_seconds`、`compact_summarize_tokens`
 - `compact_invariant_violations_total`（启用校验时）
@@ -288,7 +281,7 @@ Memory（`memory.Memory`，参见 [design-memory.md](design-memory.md)）和 Com
 5. **Loop 无条件调用、Compactor 自适应**：compact 实现不感知"是否到该压"，由策略自身决定短路或工作；Loop 不写"判断阈值再触发"分支，避免重复实现与漂移。
 6. **配对完整性是 compact 自身责任**：不外推到 provider adapter，避免重复实现。
 7. **增量基于 Session append-only**：消息下标稳定 ⇒ 单 `offset` 即可表达"已压缩边界"；不需要消息 ID 或内容指纹。无 Session 时退化为无状态全量计算。
-8. **Step 内迭代 + Step 间 hint 两层兜底**：单次 `Compact` 调用内部循环折叠到预算/无可压区/安全阀；provider 仍报 context-too-long 由 Loop 触发 `HintShrink` 重试 1 次；仍不下降 fail-fast。两层职责正交，不互相替代。
+8. **内部迭代不扩大 turn**：单次 `Compact` 调用内部循环折叠到预算/无可压区/安全阀；provider-level retry 不得隐藏在同一 turn，`HintShrink` 可由自定义 runtime 用于下一个 retry turn。
 9. **Memory 与 Compact 解耦**：Memory 走 system 段、Compact 走 messages 段；两者在请求构造阶段汇合但互不感知；预算由应用层三段分摊，不互相兜底。
 
 ## 与相邻设计的接口面

--- a/docs/design-context-management.md
+++ b/docs/design-context-management.md
@@ -14,7 +14,7 @@ tags: [agentos, context, compact, memory, budget]
 
 Context management is part of the root `blades` default Agent runtime. It is the request-view assembly layer between `session`, `compact`, `prompt`, `memory`, `tools`, and `model.Request`. It does not own long-term state and does not replace those packages. Its job is to build one model-call view and enforce budget limits.
 
-The default Agent Loop uses a private root `contextBuilder` for each model step. Applications configure budget coordination through:
+The default Agent Loop uses a private root `contextBuilder` for each turn's single primary model call. Applications configure budget coordination through:
 
 ```go
 blades.WithContextBudget(model.TokenCount{
@@ -99,7 +99,7 @@ These serve different purposes and are configured separately. Compact has its ow
 
 - `contextBuilder` reads from `session.Messages(ctx)`
 - `Compactor` transforms messages but does not write to session
-- `agentLoop.commitStep()` writes the final turn to session
+- `agentLoop.commitTurn()` writes the turn's assistant response and tool results to session
 - This keeps session as the append-only source of truth
 
 ### No Context Value Injection
@@ -121,4 +121,3 @@ compact.NewBlockSummarize(
     compact.WithSummarizer(compact.NewModelSummarizer(summaryProvider)),
 )
 ```
-

--- a/docs/design-event-agent-loop.md
+++ b/docs/design-event-agent-loop.md
@@ -114,9 +114,9 @@ func NewSteer(parts ...any) Steer {
 
 输入语义固定如下：
 
-- `Prompt`：发起一个新 turn。若当前 turn 正在运行，v1 中排队等待，不并发执行。
-- `Steer`：若当前 turn 正在运行，作为 current-turn steering 在下一个 step 边界消费，追加为当前 turn 的 user message，并在下一次 model step 构建 request 时生效；不打断正在 streaming 的 provider 调用，也不打断正在执行的 tool wave。若 Run 正处于 idle wait，`Steer` 与 `Prompt` 一样开启一个新 turn。
-- `Abort`：若当前 turn 正在运行，结束当前 turn，并携带人类可读原因；若 Run 正处于 idle wait，结束整个 Run。
+- `Prompt`：发起一个新 interaction 及其首个 turn。若当前 interaction 正在运行，作为 follow-up 排队等待，不并发执行。
+- `Steer`：若当前 turn 正在运行，在 turn 边界消费，追加为下一个 turn 的 user context，并在下一次 primary model call 构建 request 时生效；不打断正在 streaming 的 provider 调用，也不打断正在执行的 tool wave。若 Run 正处于 idle wait，`Steer` 与 `Prompt` 一样开启一个新 interaction。
+- `Abort`：若当前 turn 正在运行，结束当前 turn 及其 interaction，并携带人类可读原因；若 Run 正处于 idle wait，结束整个 Run。
 - `Pause` / `Resume`：当前 v1 保留为输入类型但默认 `llmAgent` 暂不实现暂停语义。
 
 `Abort` 与 `context.CancelFunc` 互补：`Abort` 是协议级 turn 控制，`context.CancelFunc` 负责结束整个 Run 调用栈和底层资源。
@@ -144,9 +144,9 @@ type ThinkingDelta struct {
 }
 ```
 
-当前 v1 只实现文本与 thinking 的 hot path delta。其他多模态 part 保留在最终 `TurnEnd.Parts` / Session message 中，不单独发出 `PartStart` / `PartDelta` / `PartEnd`。后续若需要 Blob 流式生命周期事件，应作为公开 Event 协议升级单独设计。
+当前 v1 只实现文本与 thinking 的 hot path delta。其他多模态 part 保留在最终 `AssistantMessageEnd.Parts`、`TurnEnd.Parts` 与 Session message 中，不单独发出 `PartStart` / `PartDelta` / `PartEnd`。后续若需要 Blob 流式生命周期事件，应作为公开 Event 协议升级单独设计。
 
-### 4.2 Step、工具与 Turn 生命周期
+### 4.2 Assistant response、工具与 Turn 生命周期
 
 工具执行由默认 `llmAgent` 编排并以事件形式公开：
 
@@ -171,6 +171,18 @@ type ToolEnd struct {
 ```
 
 `ToolStart` 只在默认 tool wave 实际调度某个工具调用时发出。Provider stream 中的 `content.ToolUse` 是 assistant message 的一部分，Loop 会收集它来决定是否进入 tool wave，但不会把它转换成 `ToolStart`，避免"模型提出调用"和"运行时开始处理"两类事件混淆。默认 Loop 不提供本地顺序/并行开关：同一 assistant message 中的 tool wave 固定按源顺序发出 `ToolStart`，实际 `Handle` 并发执行，`ToolEnd` 按完成顺序发出，而写回模型上下文的 `content.ToolResult` 仍保持 assistant 源顺序。若 provider 通过选项约束模型一次最多返回一个 tool use，这个 wave 自然退化为单工具调用。`ToolEnd.Parts` 直接复用 `tools.Result{Parts []content.Part}`，再包装为 `content.ToolResult` 写回模型上下文；若 policy deny / ask / error 在 `ToolStart` 后阻止了 `Tool.Handle`，对应 `ToolEnd` 会带 `IsError=true`。
+
+每个成功汇总的 primary `model.Provider.Stream` 响应都必须输出一个 `AssistantMessageEnd`：
+
+```go
+type AssistantMessageEnd struct {
+    Parts      []content.Part
+    StopReason StopReason
+    Usage      Usage
+}
+```
+
+它是 LLM call-local 的响应与 usage 记账事件，不跨 turn 聚合。事件刻意延迟到该响应触发的整个 tool wave 完成之后：有工具时固定顺序为 `ToolEnd`（wave 中的全部调用）→ `AssistantMessageEnd` → `TurnEnd`；无工具时为 `AssistantMessageEnd` → `TurnEnd`。因此消费者在收到 `AssistantMessageEnd` 时，既能记录本次 primary LLM call 的 usage，也能确定它触发的工具批次已经结束。Provider stream 未能汇总出完整 response 时不发出该事件；compact summarizer 等内部 `Generate` 调用也不进入用户事件流。
 
 工具控制信号在当前公开 API 中通过 `TurnEnd.Action` 聚合给 flow 层：
 
@@ -204,7 +216,7 @@ func (e TurnEnd) Text() string
 type Done struct{}
 ```
 
-`TurnEnd` 只在整个 turn 完成时输出一次。工具中间轮次不输出 `TurnEnd`；当前 v1 也不输出 `StepEnd`。`Done` 是整个 Run 的结束 sentinel，通常在 input channel 关闭、context 取消或 fatal error 后输出一次。
+`TurnEnd` 对每个 primary model call 输出一次；一个 turn 精确包含一次 call，以及该 response 触发的可选 tool wave。`Parts`、`StopReason` 与 `Usage` 都是 call-local，不再跨多次 call 聚合。工具结果需要继续交给模型时，当前 `TurnEnd` 仍先结束，Loop 再开启下一个 turn。`Done` 是整个 Run 的结束 sentinel，通常在 input channel 关闭、context 取消或 fatal error 后输出一次。
 
 运行期错误作为输出事件进入同一条流：
 
@@ -238,19 +250,19 @@ type Agent interface {
 - `agent_loop.go`：默认 LLM Agent 的私有运行循环；包含 `agentLoop`、input queue、turn loop、request 构建、provider stream、tool wave、Session commit 与 `Done` 输出。
 - `tool.go`：`NewAgentTool` 适配器，把一个 `Agent` 暴露为 `tools.Tool`。
 
-## 6. Run / Turn / Step / Tool Wave
+## 6. Run / Interaction / Turn / Tool Wave
 
 默认 `llmAgent` 使用四层运行模型：
 
-1. **Run**：长生命周期事件流，消费 input channel，顺序处理多个 turn，管理 context 取消和 `Done`。
-2. **Turn**：一次用户任务，从 `Prompt` 开始，到最终 assistant 响应、abort、错误或 max steps 结束。
-3. **Step**：一次 model provider 调用，包含 request 构建、stream 消费和 assistant delta 收集。
-4. **Tool Wave**：同一 step 中所有 `content.ToolUse` 的执行批次，产出 `ToolStart` / `ToolEnd`，并回填下一 step 的 `content.ToolResult`。
+1. **Run**：长生命周期事件流，消费 input channel，顺序处理多个 interaction，管理 context 取消和 `Done`。
+2. **Interaction**：由 `Prompt` 或 idle `Steer` 开启的私有调度分组。工具结果或 active steering 可以让它包含多个 turn；它没有对应的公开 lifecycle event。
+3. **Turn**：恰好一次 primary `model.Provider.Stream` 调用及其 response 触发的可选 tool wave。`BeforeTurn` / `AfterTurn` 与 `TurnEnd` 都按此边界执行。
+4. **Tool Wave**：同一 turn 的 assistant message 中所有 `content.ToolUse` 的执行批次，产出 `ToolStart` / `ToolEnd`，并将 `content.ToolResult` 回填给下一个 turn。
 
-单 turn 推荐流程：
+单 turn 流程：
 
-1. 收到 `Prompt` 或 idle `Steer`，触发 `Hook.BeforeTurn`，并 append 起始 user message（一次 `Session.Append`）。
-2. 构建第 0 个 model step 的 `*model.Request`。内置 request 构建按以下有序 pipeline 执行——**先 compact 再 prompt**，两段产物在最后汇合：
+1. 触发 `Hook.BeforeTurn`。interaction 首个 turn 的 `Input` 是 `Prompt` 或 idle `Steer`；纯工具续接 turn 的 `Input` 为 `nil`；active steering 续接 turn 的 `Input` 为合并后的 `Steer`。
+2. 将非 nil turn input 写入 Session，再构建本 turn 唯一一次 primary model call 的 `*model.Request`。内置 request 构建按以下有序 pipeline 执行——**先 compact 再 prompt**，两段产物在最后汇合：
    ```
    snapshot := session.Messages(ctx)            // 1. 全量原始消息（append-only 快照）
    view     := compactor.Compact(ctx, compact.Request{Messages: snapshot, TokenCounter: counter})
@@ -268,11 +280,12 @@ type Agent interface {
 4. 消费 provider stream，将文本与思考增量转为 `event.Output`；多模态 part 和 tool use 保留在最终 assistant message 中，tool use 只用于触发 tool wave。
 5. 触发 `Hook.AfterModel`。
 6. 若存在 tool use，先按 assistant 源顺序触发 `Hook.BeforeTool` 完成输入改写；随后同一 assistant message 中的 tool wave 并发执行，并由 Agent Loop 在每次调用真正调度 / 完成时发出 `ToolStart` / `ToolEnd`；识别 `ErrLoopExit` / `ErrHandoff` sentinel，并记录到 `TurnEnd.Action`。是否允许模型一次返回多个 tool use 由 provider 选项控制。
-7. 将本 step 的 `assistant` 消息与本轮 tool wave 的 `tool` 结果消息合并为一个语义组，调用一次 `Session.Append(ctx, assistantMsg, toolMsg)`。
-8. 在 model step 或 tool wave 完成后的边界非阻塞消费 input：`agent_loop.go` 的 input queue helper 先分类事件；turn commit 路径再把 `Steer` 追加为当前 turn 的 user message 并进入下一 step；`Prompt` 缓存为下一 turn 的 follow-up；`Abort` 结束当前 turn；input channel close 不 abort 当前 turn。
-9. 若没有 tool use 且没有 step-boundary steering，或收到 abort/error/tool action，输出 `TurnEnd`，触发 `Hook.AfterTurn`。`LoopExit` / `Handoff` 不进 `Session`（Session 只承载 `model.Message`）。
+7. 在全部 `ToolEnd` 之后无条件输出本次成功 response 的 `AssistantMessageEnd`。它位于 Session commit 之前，因此即使后续持久化失败，消费者仍能记录已经完成的 LLM usage。
+8. 将本 turn 的 `assistant` 消息与 tool wave 的 `tool` 结果消息合并为一个语义组，调用一次 `Session.Append(ctx, assistantMsg, toolMsg)`。
+9. 在 turn 边界非阻塞消费 input：`Steer` 合并后交给下一个 turn；`Prompt` 缓存为下一个 interaction 的 follow-up；`Abort` 结束当前 interaction；input channel close 不 abort 已开始的 interaction。
+10. 输出 call-local `TurnEnd`，再触发 `Hook.AfterTurn`。有 tool use 且无 abort/error/tool action 时开启工具续接 turn；无 tool use 时仅 active steering 会开启下一个 turn。`LoopExit` / `Handoff` 不进 `Session`（Session 只承载 `model.Message`）。
 
-Hook 回调位置固定为六个生命周期边界：`BeforeModel` / `AfterModel`（每个 model step 前后）、`BeforeTool` / `AfterTool`（每个工具调用前后）、`BeforeTurn` / `AfterTurn`（每个 turn 前后）。详见 `design-hook-extension.md`。
+Hook 回调位置固定为六个生命周期边界：`BeforeModel` / `AfterModel`（本 turn 唯一 primary model call 前后）、`BeforeTool` / `AfterTool`（每个工具调用前后）、`BeforeTurn` / `AfterTurn`（每个 turn 前后）。详见 `design-hook-extension.md`。
 
 ## 7. 扩展点
 
@@ -284,7 +297,7 @@ Hook 回调位置固定为六个生命周期边界：`BeforeModel` / `AfterModel
 - `WithPrompt(prompt.Builder)`：构建 system prompt。
 - `WithTools` / `WithToolsResolver`：配置静态或动态工具集。
 
-`RequestBuilder`、`ToolExecutor`、`WithMaxSteps` 目前不是公开 API。需要完全特殊的运行时或工具编排时，直接实现 `blades.Agent`；未来若要开放这些局部替换点，应作为独立协议变更补充测试和文档。
+`RequestBuilder`、`ToolExecutor` 与 turn limit 目前不是公开 API。需要完全特殊的运行时或工具编排时，直接实现 `blades.Agent`；未来若要开放这些局部替换点，应作为独立协议变更补充测试和文档。
 
 ## 8. Event ↔ Message 转换边界
 
@@ -295,8 +308,11 @@ Event 面向用户协议，Message 面向 provider 协议。二者通过 `conten
 - `event.Prompt` / `event.Steer` 转为 `model.Message{Role: model.RoleUser, Parts: ...}`。
 - provider 文本响应转为 `event.TextDelta`。
 - provider 思考响应转为 `event.ThinkingDelta`。
+- 完整 provider response 转为 call-local `event.AssistantMessageEnd`。
 - provider 返回的 `content.ToolUse` 保留为 assistant message part，用于触发 tool wave，不直接转为 output。
 - `tools.Result.Parts` 包装为 `content.ToolResult` 并复用同一 `[]content.Part`。
+
+`TurnEnd` 还包含 runtime error 与 tool action，因此由 Agent Loop 的 turn state 组装，不是 provider response 的直接转换。
 
 用户代码不应直接依赖 `internal/convert/`。需要完全不同的 runtime 时，实现 `blades.Agent`。
 
@@ -304,27 +320,22 @@ Event 面向用户协议，Message 面向 provider 协议。二者通过 `conten
 
 Session 历史只追加 protocol-only 的 `model.Message`，并以"语义组"为原子单元写入：
 
-1. **turn 起始**：append 起始 `Prompt` 或 idle `Steer` 转换出的 user message（一次 `Append(ctx, userMsg)`）。
-2. **每个 model step + tool wave 完成后**：将本 step 的 `assistant` 消息与同 step 的 `tool` 结果消息作为一组，调用一次 `Append(ctx, assistantMsg, toolMsg)`。该组写入是 step 级原子单元，避免崩溃留下"有 tool_call 但无 tool_result"的半截历史。
-3. **step / tool-wave 边界输入**：active turn 中收到的 `Steer` append 为 user message，并触发同一 turn 的下一次 model step；active turn 中收到的 `Prompt` 只排队为下一 turn 的 follow-up。
-4. final assistant message 完成且无新工具调用后输出 `TurnEnd`。
+1. **turn 输入**：interaction 首个 `Prompt` / idle `Steer` append 为 user message；active steering 在下一个 turn 开始时通过 `AppendUser` 合并；纯工具续接 turn 不追加 user message。
+2. **每个 turn + tool wave 完成后**：将本 turn 的 `assistant` 消息与同 turn 的 `tool` 结果消息作为一组，调用一次 `Append(ctx, assistantMsg, toolMsg)`。该组写入是 turn 级原子单元，避免崩溃留下"有 tool_call 但无 tool_result"的半截历史。
+3. **turn 边界输入**：active interaction 中收到的 `Steer` 触发下一个 turn；`Prompt` 只排队为下一个 interaction 的 follow-up。
+4. 每个成功汇总的 primary response 都先输出 `AssistantMessageEnd`，随后每个 turn 都输出 `TurnEnd`；是否还会继续工具 turn 不改变该规则。
 
-输入队列本身不写 Session。`nextTurnStart` / `drainStepBoundaryInputs` 只把 channel 事件分类为"开启 turn"、"current-turn steering"、"follow-up prompt"或"abort"；所有 `model.Message` 创建、hook 执行和 `Session.Append` 都集中在 `agent_loop.go` 的 turn / step commit 路径。这样不会出现 queue helper 持有 `session.Session`、又悄悄改变 transcript 的隐式副作用。
+输入队列本身不写 Session。`nextInteractionStart` / `drainTurnBoundaryInputs` 只把 channel 事件分类为"开启 interaction"、"next-turn steering"、"follow-up prompt"或"abort"；所有 `model.Message` 创建、hook 执行和 `Session.Append` 都集中在 `agent_loop.go` 的 turn commit 路径。这样不会出现 queue helper 持有 `session.Session`、又悄悄改变 transcript 的隐式副作用。
 
 **不写回 Session 的内容**：compact view、summary、被截断的 tool result 视图、以及 `event.LoopExit` / `event.Handoff` 等运行时控制信号。控制信号只出现在 `TurnEnd.Action`。Compactor 的 rolling state 通过 `session.State()` 的私有 key（保留前缀 `__compact_*__`，参见 [design-session.md](design-session.md) §State 键命名空间）持久化，与协议历史正交，不会出现在 `Session.Messages()` 中。
 
-Stateless mode 不读取 session history，但仍维护 turn-local transcript 以支持多 step 工具循环。Compact 只在构建 request 前运行，输入是 session 快照 + turn-local pending parts，输出必须满足 provider message invariant。
+Stateless mode 不读取持久化 session history，但 interaction 内仍维护足够的 transcript，使工具结果能够进入下一个 turn。Compact 只在构建 request 前运行，输出必须满足 provider message invariant。
 
-### 上下文超长的两层兜底
+### 上下文超长与 retry 边界
 
-provider 真实 token 计费与 Compactor 基于 `model.TokenCounter` 的 message view 估算之间总会存在偏差，因此在 Compactor 自身的[迭代压缩契约](design-compact.md#迭代压缩契约)之上，Loop 再提供一层 step 间的 hint 重试：
+Compactor 可以在一次 `Compact` 调用内迭代折叠消息；这仍属于当前 turn 的 request 构建阶段，尚未发生 primary model call。`NewModelSummarizer` 在此期间直接调用 `Provider.Generate`，但该内部摘要调用不属于 Agent turn，也不产生用户事件。
 
-| 层级 | 触发主体 | 触发条件 | 行为 |
-|------|----------|----------|------|
-| Step 内迭代 | Compactor 自身 | 当前视图估算超 `MaxTokens` | 在单次 `Compact` 调用内循环折叠批次（推进 offset / 调 Summarize LLM）直到 ① 满足预算 ② offset 抵达 `len(msgs) - KeepRecent` 无可压区 ③ 触发安全阀 |
-| Step 间 hint | Agent Loop | provider 实际返回 context-too-long 类错误 | Loop 透传 `compact.WithHint(ctx, HintShrink)` 重新进入**同一 step 的第二次**请求构造；Compactor 在 hint 模式下必须返回 token 严格单调下降的视图。最大重试 1 次；仍未下降 → `event.Error` fail-fast 终止 turn |
-
-两层是正交关系，不互相替代：step 内迭代解决"按预算逼近"，step 间 hint 解决"估算与真实账本之间的最后一公里"。Loop 不在估算阶段做任何阈值判断（保持 [触发时机](design-compact.md#触发时机) 中"Loop 无条件调用、Compactor 自适应"的契约）。
+当前默认 Loop 不隐藏 provider-level context-too-long retry：`Provider.Stream` 返回错误时，本 turn 以 `TurnEnd.Err` 和 runtime `Error` 结束，且因为没有完整 response，不发 `AssistantMessageEnd`。`compact.HintShrink` 可供自定义 runtime 构建 retry view；若未来默认 Loop 增加 provider retry，每次新的 `Provider.Stream` 尝试也必须开启新 turn，不能在一个 turn 中放入多次 primary LLM call。
 
 ## 与红线对照
 

--- a/docs/design-event-agent-loop.md
+++ b/docs/design-event-agent-loop.md
@@ -172,7 +172,7 @@ type ToolEnd struct {
 
 `ToolStart` 只在默认 tool wave 实际调度某个工具调用时发出。Provider stream 中的 `content.ToolUse` 是 assistant message 的一部分，Loop 会收集它来决定是否进入 tool wave，但不会把它转换成 `ToolStart`，避免"模型提出调用"和"运行时开始处理"两类事件混淆。默认 Loop 不提供本地顺序/并行开关：同一 assistant message 中的 tool wave 固定按源顺序发出 `ToolStart`，实际 `Handle` 并发执行，`ToolEnd` 按完成顺序发出，而写回模型上下文的 `content.ToolResult` 仍保持 assistant 源顺序。若 provider 通过选项约束模型一次最多返回一个 tool use，这个 wave 自然退化为单工具调用。`ToolEnd.Parts` 直接复用 `tools.Result{Parts []content.Part}`，再包装为 `content.ToolResult` 写回模型上下文；若 policy deny / ask / error 在 `ToolStart` 后阻止了 `Tool.Handle`，对应 `ToolEnd` 会带 `IsError=true`。
 
-每个成功汇总的 primary `model.Provider.Stream` 响应都必须输出一个 `AssistantMessageEnd`：
+每个成功汇总且被全部 `AfterModel` hook 接受的 primary `model.Provider.Stream` 响应都必须输出一个 `AssistantMessageEnd`：
 
 ```go
 type AssistantMessageEnd struct {
@@ -182,7 +182,7 @@ type AssistantMessageEnd struct {
 }
 ```
 
-它是 LLM call-local 的响应与 usage 记账事件，不跨 turn 聚合。事件刻意延迟到该响应触发的整个 tool wave 完成之后：有工具时固定顺序为 `ToolEnd`（wave 中的全部调用）→ `AssistantMessageEnd` → `TurnEnd`；无工具时为 `AssistantMessageEnd` → `TurnEnd`。因此消费者在收到 `AssistantMessageEnd` 时，既能记录本次 primary LLM call 的 usage，也能确定它触发的工具批次已经结束。Provider stream 未能汇总出完整 response 时不发出该事件；compact summarizer 等内部 `Generate` 调用也不进入用户事件流。
+它是 LLM call-local 的响应与 usage 记账事件，不跨 turn 聚合。事件刻意延迟到该响应触发的整个 tool wave 完成之后：有工具时固定顺序为 `ToolEnd`（wave 中的全部调用）→ `AssistantMessageEnd` → `TurnEnd`；无工具时为 `AssistantMessageEnd` → `TurnEnd`。因此消费者在收到 `AssistantMessageEnd` 时，既能记录本次 primary LLM call 的 usage，也能确定它触发的工具批次已经结束。Provider stream 未能汇总出完整 response，或任一 `AfterModel` hook 返回错误时，不发出该事件；compact summarizer 等内部 `Generate` 调用也不进入用户事件流。
 
 工具控制信号在当前公开 API 中通过 `TurnEnd.Action` 聚合给 flow 层：
 
@@ -280,7 +280,7 @@ type Agent interface {
 4. 消费 provider stream，将文本与思考增量转为 `event.Output`；多模态 part 和 tool use 保留在最终 assistant message 中，tool use 只用于触发 tool wave。
 5. 触发 `Hook.AfterModel`。
 6. 若存在 tool use，先按 assistant 源顺序触发 `Hook.BeforeTool` 完成输入改写；随后同一 assistant message 中的 tool wave 并发执行，并由 Agent Loop 在每次调用真正调度 / 完成时发出 `ToolStart` / `ToolEnd`；识别 `ErrLoopExit` / `ErrHandoff` sentinel，并记录到 `TurnEnd.Action`。是否允许模型一次返回多个 tool use 由 provider 选项控制。
-7. 在全部 `ToolEnd` 之后无条件输出本次成功 response 的 `AssistantMessageEnd`。它位于 Session commit 之前，因此即使后续持久化失败，消费者仍能记录已经完成的 LLM usage。
+7. 在全部 `ToolEnd` 之后输出被 `AfterModel` 接受的 response 对应的 `AssistantMessageEnd`。它位于 Session commit 之前，因此即使后续持久化失败，消费者仍能记录已经完成的 LLM usage。
 8. 将本 turn 的 `assistant` 消息与 tool wave 的 `tool` 结果消息合并为一个语义组，调用一次 `Session.Append(ctx, assistantMsg, toolMsg)`。
 9. 在 turn 边界非阻塞消费 input：`Steer` 合并后交给下一个 turn；`Prompt` 缓存为下一个 interaction 的 follow-up；`Abort` 结束当前 interaction；input channel close 不 abort 已开始的 interaction。
 10. 输出 call-local `TurnEnd`，再触发 `Hook.AfterTurn`。有 tool use 且无 abort/error/tool action 时开启工具续接 turn；无 tool use 时仅 active steering 会开启下一个 turn。`LoopExit` / `Handoff` 不进 `Session`（Session 只承载 `model.Message`）。

--- a/docs/design-hook-extension.md
+++ b/docs/design-hook-extension.md
@@ -36,11 +36,11 @@ import (
 // Six methods cover the full Agent Loop boundary set; embed hook.Noop to
 // inherit no-op defaults and override only the methods you care about.
 type Hook interface {
-    // BeforeModel runs before each model step. Mutate *req in place
+    // BeforeModel runs before the turn's primary model call. Mutate *req in place
     // (e.g. inject system text, append messages, narrow tool spec).
     BeforeModel(ctx context.Context, req *model.Request) error
 
-    // AfterModel runs after each successful model step. If provider streaming
+    // AfterModel runs after each successful primary model call. If provider streaming
     // fails, it is called for observation with resp == nil and err set; the
     // original provider error still terminates the turn.
     AfterModel(ctx context.Context, req *model.Request, resp *model.Response, err error) error
@@ -51,14 +51,14 @@ type Hook interface {
     // AfterTool runs after each tool wave item completes (including policy
     // denial or tool errors) and before ToolEnd is emitted / tool result is
     // committed. Mutate result.Parts in place to rewrite the tool result seen
-    // by both event output and the next model step.
+    // by both event output and the next turn.
     AfterTool(ctx context.Context, call *ToolCall, result *tools.Result, err error) error
 
-    // BeforeTurn runs once at the start of a turn, before any model step.
+    // BeforeTurn runs once at the start of a turn, before its model call.
     BeforeTurn(ctx context.Context, t *Turn) error
 
     // AfterTurn runs once at the end of a turn (including errors).
-    // summary aggregates the parts / stop reason / usage of the turn.
+    // summary contains the call-local parts / stop reason / usage of the turn.
     AfterTurn(ctx context.Context, t *Turn, summary *TurnSummary, err error) error
 }
 
@@ -86,14 +86,15 @@ type ToolCall struct {
     Input     json.RawMessage
 }
 
-// Turn is the carrier passed to BeforeTurn / AfterTurn.
+// Turn is the carrier passed to BeforeTurn / AfterTurn. Input is nil for a
+// turn started only by tool results from the preceding turn.
 type Turn struct {
     AgentName string
     Turn      int
     Input     event.Input
 }
 
-// TurnSummary aggregates the result of a turn for AfterTurn observers.
+// TurnSummary contains call-local results for AfterTurn observers.
 // Current v1 treats AfterTurn as observation-only; mutations do not rewrite
 // already emitted events or committed session messages.
 type TurnSummary struct {
@@ -118,12 +119,13 @@ func Abort(reason string) error { return &AbortError{Reason: reason} }
 
 字段约定：
 
-- `AgentName` / `Turn` 用于在事件流中关联一轮执行；当前会话**不**通过 carrier 字段携带，统一由 `session.FromContext(ctx)` 读取（与 framework 的 ctx 三准则一致），避免同一信息在 ctx 与 carrier 上重复。
-- `*model.Request` / `*model.Response` 使用 v1 `model.Provider` 协议；Stream 路径下 Loop 消费 chunk 序列、发出增量事件，并在 step 完成后汇总为 `*model.Response` 再触发 `AfterModel`。
+- `AgentName` / `Turn` 用于在事件流中关联一次 primary model call 及其 tool wave；当前会话**不**通过 carrier 字段携带，统一由 `session.FromContext(ctx)` 读取（与 framework 的 ctx 三准则一致），避免同一信息在 ctx 与 carrier 上重复。
+- `*model.Request` / `*model.Response` 使用 v1 `model.Provider` 协议；Stream 路径下 Loop 消费 chunk 序列、发出增量事件，并在 call 完成后汇总为 `*model.Response` 再触发 `AfterModel`。
 - `tools.Tool` 使用 v1 两方法接口；如需工具名调用 `call.Tool.Spec().Name`，carrier 不再单独保留 `ToolName` 字段。
 - `event.Input` 使用 v1 文本由 `event.NewPrompt` / `event.NewSteer` 构造，具体类型为 `event.Prompt` / `event.Steer`。
 - `Parts` 直接使用 `content.Part`。
-- `Before/AfterModel` 即 model **step 边界**：一个 turn 可能包含多次 step（多轮 tool call），每个 step 对应一对 `BeforeModel` / `AfterModel`。当前 v1 不输出 `event.StepEnd`，`BeforeTurn` / `AfterTurn` 才是 turn 边界。
+- `Before/AfterModel` 与 `Before/AfterTurn` 是 **1:1** 的 primary-call 边界：一个 turn 只包含一次 `Provider.Stream`。该 response 触发的 tool wave 仍属于此 turn；若要把 tool result 反馈给模型，Loop 会结束当前 turn 并开启新 turn。纯工具续接 turn 的 `Turn.Input` 为 `nil`，active steering 续接 turn 的 `Input` 为 `event.Steer`。
+- `AssistantMessageEnd` 在全部 `ToolEnd` 后、对应 `TurnEnd` 前输出；`TurnSummary.Usage` 与两类事件中的 usage 都只描述本次 call。Compactor 内部用于摘要的 `Provider.Generate` 不触发这些 hook 或 event 边界。
 
 ## 3. 注册与组合
 
@@ -176,7 +178,7 @@ func (Guardrail) AfterTool(ctx context.Context, call *hook.ToolCall, result *too
 
 ### 4.3 拦截
 
-任意方法返回 `hook.Abort(reason)` 触发协议级 turn 中止。`Before*` 中止跳过对应调用；`AfterModel` 中止不再触发后续 tool wave 或下一 step；`AfterTool` 中止不把当前 tool result 反馈给模型，turn 以 abort 收尾。其它非 nil error 作为 fatal runtime error 进入输出流。
+任意方法返回 `hook.Abort(reason)` 触发协议级 turn 中止。`Before*` 中止跳过对应调用；`AfterModel` 中止不再触发后续 tool wave 或下一 turn；`AfterTool` 中止不把当前 tool result 反馈给模型，turn 以 abort 收尾。其它非 nil error 作为 fatal runtime error 进入输出流。
 
 ```go
 type Deny struct{ hook.Noop }
@@ -204,9 +206,9 @@ func (Deny) BeforeTool(ctx context.Context, call *hook.ToolCall) error {
 
 | 方法 | abort 含义 |
 |---|---|
-| `BeforeTurn` | 跳过本 turn 的所有 model step / tool wave，直接进 `TurnEnd` |
-| `BeforeModel` | 跳过本 step 的 provider 调用（不发请求），结束当前 step；若已无后续 step → turn 终止 |
-| `AfterModel` | 不再触发后续 tool wave 或下一个 step，turn 提前结束 |
+| `BeforeTurn` | 跳过本 turn 的 primary model call / tool wave，直接进 `TurnEnd` |
+| `BeforeModel` | 跳过本 turn 的 provider 调用（不发请求），直接结束 turn |
+| `AfterModel` | 不再触发后续 tool wave 或下一个 turn，当前 turn 提前结束；已成功汇总的 response 仍输出 `AssistantMessageEnd` |
 | `BeforeTool` | 不执行当前 tool wave，turn 以 abort 收尾；若要给模型反馈可反思的工具拒绝结果，应使用 `policy.Policy` 的 `Deny` |
 | `AfterTool` | 不把当前 tool result 反馈给模型，turn 以 abort 收尾 |
 | `AfterTurn` | 当前 v1 忽略返回错误；无法回滚已发出事件或已提交 Session 的消息 |

--- a/docs/design-hook-extension.md
+++ b/docs/design-hook-extension.md
@@ -208,7 +208,7 @@ func (Deny) BeforeTool(ctx context.Context, call *hook.ToolCall) error {
 |---|---|
 | `BeforeTurn` | 跳过本 turn 的 primary model call / tool wave，直接进 `TurnEnd` |
 | `BeforeModel` | 跳过本 turn 的 provider 调用（不发请求），直接结束 turn |
-| `AfterModel` | 不再触发后续 tool wave 或下一个 turn，当前 turn 提前结束；已成功汇总的 response 仍输出 `AssistantMessageEnd` |
+| `AfterModel` | 不再触发后续 tool wave 或下一个 turn，丢弃已汇总的 response，且不输出 `AssistantMessageEnd` |
 | `BeforeTool` | 不执行当前 tool wave，turn 以 abort 收尾；若要给模型反馈可反思的工具拒绝结果，应使用 `policy.Policy` 的 `Deny` |
 | `AfterTool` | 不把当前 tool result 反馈给模型，turn 以 abort 收尾 |
 | `AfterTurn` | 当前 v1 忽略返回错误；无法回滚已发出事件或已提交 Session 的消息 |

--- a/docs/design-memory.md
+++ b/docs/design-memory.md
@@ -106,16 +106,16 @@ Memory 与 Compact（[design-compact.md](design-compact.md)）在 Agent Loop 中
 | 调用入口 | `prompt.Memory(...)` section → `prompt.Builder.Build` | Agent Loop 请求构造阶段调用 `compactor.Compact(ctx, compact.Request{Messages: snapshot, TokenCounter: counter})` |
 | 数据源 | 跨 turn / 跨 session 的长期上下文存储 | 当前 Session 的 `Messages()` 快照 |
 | 是否进入 Session | 不进 | 不进（仅 rolling state 进 `State()`） |
-| 是否每 step 重新计算 | 是（每个 model step 重新 `Recall`，除非 section 内部缓存） | 是（带状态 Compactor 通过 `__compact_*__` state 增量复用） |
+| 是否每 turn 重新计算 | 是（每个 primary model call 前重新 `Recall`，除非 section 内部缓存） | 是（带状态 Compactor 通过 `__compact_*__` state 增量复用） |
 | 体量控制责任方 | Memory 实现 + 应用层（`Query.Limit`、section 内 token 估算） | Compactor（`MaxTokens`、`KeepRecent`、迭代折叠） |
 
 由此推出的应用层使用约束：
 
 - **不要依赖 Compact 兜底 memory**：Compactor 的输入只看 messages，永远不会再次裁剪 system 段中的 memory 召回结果。memory 段超限会直接堆到 system 上，一旦 provider 报 context-too-long，Loop 的 `HintShrink` 也只会让 Compactor 进一步压缩 messages，无法替你削减 memory。
 - **预算分摊在应用层完成**：建议在应用初始化处把 provider 上下文上限分为三段——`SystemBudget`（含 memory 召回 + 静态系统指令）/ `MessagesBudget`（compact 的 `MaxTokens`）/ `ResponseReserve`（输出预留），并分别注入 prompt 与 compact 的配置。
-- **每 step 重新 Recall 是默认行为**：让 query 随当前任务自适应；如果 memory 后端调用昂贵，应用层应自行在 prompt section 中实现 per-turn 缓存，不要要求 core 层做。
+- **每 turn 重新 Recall 是默认行为**：让 query 随当前任务自适应；如果 memory 后端调用昂贵，应用层应自行在 prompt section 中实现 per-turn 缓存，不要要求 core 层做。
 - **Forget 与 Compact 的 rolling summary 无关**：`mem.Forget(ctx, entry)` 删除的是长期上下文条目，不会影响任何 Session 的 `__compact_summary_*__` 状态；反之 Compactor 的 offset 推进也不会触发 memory 的 Forget。两者生命周期独立。
-- **Memory 召回不进入 compact 增量历史**：召回结果只存在于本次请求的 system 段，下次 step 时由 prompt builder 重新生成；不会被 Compactor 当作"未压缩消息"持续累积。
+- **Memory 召回不进入 compact 增量历史**：召回结果只存在于本次请求的 system 段，下个 turn 时由 prompt builder 重新生成；不会被 Compactor 当作"未压缩消息"持续累积。
 
 如需观测 system 段（含 memory）与 messages 段（含 compact view）的 token 占比，应用层通过 hook 或 observability 自行采样，core 不在 Memory 或 Compactor 接口上加协同字段。
 

--- a/docs/design-policy-mode.md
+++ b/docs/design-policy-mode.md
@@ -172,16 +172,17 @@ core 不内置审计存储；可观测性走两条通路：
 ```
 Run
 └── Turn
-    └── Step
-        ├── Hook.BeforeModel     ← 模型请求改写在此发生（注入 system、裁剪 tools、调整 sampling）
-        ├── model.Generate / Stream
-        └── Tool Wave (默认并行，可配置顺序)
-            ├── Hook.BeforeTool
-            ├── event.ToolStart
-            ├── policy.Check(ToolRequest{Tool, Input}) ← v1 唯一 Policy 边界
-            ├── tool.Handle
-            ├── Hook.AfterTool
-            └── event.ToolEnd
+    ├── Hook.BeforeModel     ← 模型请求改写在此发生（注入 system、裁剪 tools、调整 sampling）
+    ├── model.Stream         ← 每个 Turn 恰好一次 primary call
+    ├── Tool Wave (默认并行，可配置顺序)
+    │   ├── Hook.BeforeTool
+    │   ├── event.ToolStart
+    │   ├── policy.Check(ToolRequest{Tool, Input}) ← v1 唯一 Policy 边界
+    │   ├── tool.Handle
+    │   ├── Hook.AfterTool
+    │   └── event.ToolEnd
+    ├── event.AssistantMessageEnd
+    └── event.TurnEnd
 ```
 
 ### 与 tools

--- a/docs/design-session.md
+++ b/docs/design-session.md
@@ -102,7 +102,7 @@ Session 与 compaction **完全解耦**：
   1. `msgs, _ := session.Messages(ctx)`
   2. `view, err := compactor.Compact(ctx, compact.Request{Messages: msgs, TokenCounter: counter})`  // 纯变换，不副作用；Compactor 自身决定是否短路
   3. 用 `view` 组装 `model.Request` 调用 provider
-  4. provider 返回的 final assistant 消息与本 step 的全部 tool 结果作为一个语义组通过一次 `Append` 写回 Session（仍然是完整原始消息，不是压缩后的视图）
+  4. provider 返回的 assistant 消息与本 turn 的全部 tool 结果作为一个语义组通过一次 `Append` 写回 Session（仍然是完整原始消息，不是压缩后的视图）
 - compactor 的滚动状态（如 summarize 的 `offset` / `summaryContent`）通过 `Session.State()` 持久化，避免每轮重算。参见 [design-compact.md](design-compact.md) §3。
 
 ### 为什么 append-only 是增量压缩的前提
@@ -170,7 +170,7 @@ Session core 不提供 Manager 抽象。常见做法由应用层组合：
 
 - **单实例内**：`Append` / `Messages` 串行可见；并发安全由实现自身保证（`sessionInMemory` 使用并发容器；远程后端可用 mutex 或追加日志）。
 - **跨进程**：core 不规定一致性级别。具体后端在自身文档中声明（last-write-wins 不适用，因为没有覆盖语义；纯追加场景下后端通常实现"顺序追加 + 单调读"）。
-- **推荐使用模式**：以 step 为原子单元写入——turn 起始 `Append(ctx, userMsg)`；每个 model step + tool wave 完成后 `Append(ctx, assistantMsg, toolMsg)` 一次性写入语义组（参见 [design-event-agent-loop.md](design-event-agent-loop.md) §9）；compaction 不写回 Session（参见 §4）；不要把这些操作拆成长事务。
+- **推荐使用模式**：以 turn 为原子单元写入——有输入的 turn 起始时 `Append(ctx, userMsg)`（纯工具续接 turn 无 user message）；本 turn 唯一一次 primary model call + tool wave 完成后 `Append(ctx, assistantMsg, toolMsg)` 一次性写入语义组（参见 [design-event-agent-loop.md](design-event-agent-loop.md) §9）；compaction 不写回 Session（参见 §4）；不要把这些操作拆成长事务。
 - 应用层可基于 `State()` 或后端自身字段实现版本号、租约、乐观锁，core 不内置。
 
 

--- a/docs/design-tool-system.md
+++ b/docs/design-tool-system.md
@@ -204,7 +204,7 @@ func (e *ErrHandoff) Error() string { return "tools: handoff to " + e.Agent }
 
 `tools/` 不决定工具何时执行、是否并发、如何取消、如何把结果写回 provider 消息。当前 v1 的默认编排由根包 `llmAgent` 内部的 tool wave 完成；它不是公开可替换的 `ToolExecutor` 接口。需要完全改写编排语义时，应实现一个自定义 `blades.Agent`。
 
-工具批次是否出现多个调用由模型/provider 决定，不由本地 `tools` 包配置。默认 Loop 对同一 assistant message 中的 tool wave 采用固定语义：`ToolStart` 按 assistant 源顺序发出，实际 `Handle` 并发执行，`ToolEnd` 按完成顺序发出，`content.ToolResult` 按 assistant 源顺序写回 Session。多个工具同时返回控制信号时，`TurnEnd.Action` 取 assistant 源顺序的第一个 action，保证确定性。
+工具批次是否出现多个调用由模型/provider 决定，不由本地 `tools` 包配置。默认 Loop 对同一 assistant message 中的 tool wave 采用固定语义：`ToolStart` 按 assistant 源顺序发出，实际 `Handle` 并发执行，`ToolEnd` 按完成顺序发出，全部 `ToolEnd` 之后输出 call-local `AssistantMessageEnd`，再输出对应 `TurnEnd`；`content.ToolResult` 按 assistant 源顺序写回 Session。多个工具同时返回控制信号时，`TurnEnd.Action` 取 assistant 源顺序的第一个 action，保证确定性。
 
 默认 tool wave 负责：
 

--- a/event/input.go
+++ b/event/input.go
@@ -2,14 +2,14 @@ package event
 
 import "github.com/go-kratos/blades/content"
 
-// Prompt starts a new turn with the given content parts.
+// Prompt starts a new interaction with the given content parts.
 type Prompt struct {
 	Parts []content.Part
 }
 
 func (Prompt) input() {}
 
-// Steer injects additional context or correction into the current run.
+// Steer injects additional context or correction into the next turn.
 type Steer struct {
 	Parts []content.Part
 }

--- a/event/message.go
+++ b/event/message.go
@@ -2,7 +2,9 @@ package event
 
 import "github.com/go-kratos/blades/content"
 
-// AssistantMessageEnd signals completion of one assistant model response.
+// AssistantMessageEnd reports one completed assistant model response.
+// The default Agent emits it after the response's tool wave has finished and
+// before the corresponding TurnEnd.
 type AssistantMessageEnd struct {
 	Parts      []content.Part
 	StopReason StopReason

--- a/event/terminal.go
+++ b/event/terminal.go
@@ -2,7 +2,7 @@ package event
 
 import "github.com/go-kratos/blades/content"
 
-// StopReason indicates why a turn ended.
+// StopReason indicates why a model call stopped or its turn was aborted.
 type StopReason string
 
 const (
@@ -19,7 +19,7 @@ type Usage struct {
 	OutputTokens int64
 }
 
-// TurnEnd signals the completion of a full turn (one or more steps).
+// TurnEnd signals completion of one primary model call and its tool wave.
 type TurnEnd struct {
 	Parts      []content.Part
 	StopReason StopReason

--- a/flow/sequential_test.go
+++ b/flow/sequential_test.go
@@ -1,0 +1,35 @@
+package flow
+
+import (
+	"testing"
+
+	"github.com/go-kratos/blades/content"
+	"github.com/go-kratos/blades/event"
+)
+
+func TestDefaultBridgeUsesLastTurn(t *testing.T) {
+	t.Parallel()
+
+	output := make(chan event.Output, 4)
+	output <- event.TurnEnd{Parts: []content.Part{content.Text{Text: "intermediate"}}}
+	output <- event.AssistantMessageEnd{Parts: []content.Part{content.Text{Text: "final"}}}
+	output <- event.TurnEnd{Parts: []content.Part{content.Text{Text: "final"}}}
+	output <- event.Done{}
+	close(output)
+
+	input := defaultBridge(output)
+	next, ok := <-input
+	if !ok {
+		t.Fatal("defaultBridge closed without an input")
+	}
+	prompt, ok := next.(event.Prompt)
+	if !ok {
+		t.Fatalf("defaultBridge output = %T, want event.Prompt", next)
+	}
+	if got := content.TextFromParts(prompt.Parts); got != "final" {
+		t.Fatalf("defaultBridge text = %q, want final", got)
+	}
+	if _, ok := <-input; ok {
+		t.Fatal("defaultBridge emitted more than one input")
+	}
+}

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -10,7 +10,8 @@ import (
 	"github.com/go-kratos/blades/tools"
 )
 
-// Hook defines lifecycle callbacks for the agent loop.
+// Hook defines lifecycle callbacks for the agent loop. A turn wraps one
+// primary model call and the tool wave produced by its response.
 type Hook interface {
 	BeforeModel(ctx context.Context, req *model.Request) error
 	AfterModel(ctx context.Context, req *model.Request, resp *model.Response, err error) error
@@ -41,14 +42,15 @@ type ToolCall struct {
 	Input     json.RawMessage
 }
 
-// Turn carries context for BeforeTurn/AfterTurn hooks.
+// Turn carries context for BeforeTurn/AfterTurn hooks. Input is nil for a turn
+// started only by tool results from the preceding turn.
 type Turn struct {
 	AgentName string
 	Turn      int
 	Input     event.Input
 }
 
-// TurnSummary aggregates the result of a completed turn.
+// TurnSummary contains call-local results for a completed turn.
 type TurnSummary struct {
 	Parts      []content.Part
 	StopReason model.StopReason

--- a/internal/convert/message_to_event.go
+++ b/internal/convert/message_to_event.go
@@ -8,9 +8,6 @@ import (
 
 // ChunkToOutputs converts a model.Chunk into output events.
 func ChunkToOutputs(chunk *model.Chunk) []event.Output {
-	if chunk == nil {
-		return nil
-	}
 	var outputs []event.Output
 	for _, p := range chunk.Parts {
 		switch v := p.(type) {
@@ -26,32 +23,12 @@ func ChunkToOutputs(chunk *model.Chunk) []event.Output {
 // ResponseToAssistantMessageEnd converts a model.Response into an
 // AssistantMessageEnd event.
 func ResponseToAssistantMessageEnd(resp *model.Response) event.AssistantMessageEnd {
-	var parts []content.Part
-	var stopReason model.StopReason
-	var usage model.Usage
-	if resp != nil && resp.Message != nil {
-		parts = resp.Message.Parts
-	}
-	if resp != nil {
-		stopReason = resp.StopReason
-		usage = resp.Usage
-	}
 	return event.AssistantMessageEnd{
-		Parts:      parts,
-		StopReason: event.StopReason(stopReason),
-		Usage:      event.Usage{InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens},
-	}
-}
-
-// ResponseToTurnEnd converts a model.Response into a TurnEnd event.
-func ResponseToTurnEnd(resp *model.Response) event.TurnEnd {
-	var parts []content.Part
-	if resp.Message != nil {
-		parts = resp.Message.Parts
-	}
-	return event.TurnEnd{
-		Parts:      parts,
+		Parts:      resp.Message.Parts,
 		StopReason: event.StopReason(resp.StopReason),
-		Usage:      event.Usage{InputTokens: resp.Usage.InputTokens, OutputTokens: resp.Usage.OutputTokens},
+		Usage: event.Usage{
+			InputTokens:  resp.Usage.InputTokens,
+			OutputTokens: resp.Usage.OutputTokens,
+		},
 	}
 }

--- a/option.go
+++ b/option.go
@@ -55,15 +55,6 @@ func WithHooks(h ...hook.Hook) AgentOption {
 	}
 }
 
-// WithAssistantMessageEnd configures whether the agent emits
-// event.AssistantMessageEnd after each model response. It is disabled by
-// default.
-func WithAssistantMessageEnd(enabled bool) AgentOption {
-	return func(a *llmAgent) {
-		a.sendAssistantMessageEnd = enabled
-	}
-}
-
 // WithCompact sets the context compactor.
 func WithCompact(c compact.Compactor) AgentOption {
 	return func(a *llmAgent) {

--- a/runner.go
+++ b/runner.go
@@ -34,6 +34,7 @@ func NewRunner(agent Agent, opts ...RunnerOption) *Runner {
 }
 
 // Run sends a single input and blocks until the agent produces a final result.
+// If the interaction uses multiple model calls, the last TurnEnd is returned.
 // Runtime errors are extracted from event.Error.
 func (r *Runner) Run(ctx context.Context, in event.Input) (Result, error) {
 	output, err := r.RunStream(ctx, in)

--- a/session/session.go
+++ b/session/session.go
@@ -14,7 +14,7 @@ type Session interface {
 	State() map[string]any
 	SetState(key string, value any)
 	Append(ctx context.Context, msgs ...*model.Message) error
-	// AppendUser merges parts into the last message when it is a RoleUser or
+	// AppendUser merges steering parts into the last message when it is a RoleUser or
 	// RoleTool message, otherwise appends a new RoleUser message. Merging into a
 	// trailing RoleTool message keeps that message's role, so its tool results and
 	// the appended parts stay in one message and provider adapters still emit the

--- a/tests/agent/llm_agent_test.go
+++ b/tests/agent/llm_agent_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"iter"
 	"reflect"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -53,9 +54,9 @@ func TestLLMAgentExecutesCalculateTool(t *testing.T) {
 	defer cancel()
 	inputs := make(chan event.Input, 1)
 	inputs <- event.NewPrompt("What is 123 * 456?")
+	close(inputs)
 
-	outputs, err := collectAgentOutputs(ctx, agent, inputs)
-	cancel()
+	outputs, err := collectAllAgentOutputs(ctx, agent, inputs)
 	assert.NoError(t, err)
 
 	toolEnd, ok := findToolEnd(outputs, "calc-1")
@@ -65,13 +66,33 @@ func TestLLMAgentExecutesCalculateTool(t *testing.T) {
 	assert.Equal(t, "123 * 456 = 56088", textFromParts(toolEnd.Parts))
 	assert.Equal(t, 1, countToolStarts(outputs, "calc-1"))
 
-	assert.Empty(t, assistantMessageEnds(outputs))
+	messageEnds := assistantMessageEnds(outputs)
+	if assert.Len(t, messageEnds, 2) {
+		assert.Equal(t, event.StopToolUse, messageEnds[0].StopReason)
+		assert.Equal(t, event.Usage{InputTokens: 10, OutputTokens: 3}, messageEnds[0].Usage)
+		assert.Equal(t, "Let me calculate that.", messageEnds[0].Text())
+		assert.Equal(t, event.StopEnd, messageEnds[1].StopReason)
+		assert.Equal(t, event.Usage{InputTokens: 20, OutputTokens: 4}, messageEnds[1].Usage)
+		assert.Equal(t, "The result is 56088.", messageEnds[1].Text())
+	}
 
-	turnEnd, ok := lastTurnEnd(outputs)
-	assert.True(t, ok)
-	assert.Equal(t, event.StopEnd, turnEnd.StopReason)
-	assert.Equal(t, "The result is 56088.", textFromParts(turnEnd.Parts))
-	assert.Equal(t, event.Usage{InputTokens: 30, OutputTokens: 7}, turnEnd.Usage)
+	turns := turnEnds(outputs)
+	if assert.Len(t, turns, 2) {
+		assert.Equal(t, event.StopToolUse, turns[0].StopReason)
+		assert.Equal(t, event.Usage{InputTokens: 10, OutputTokens: 3}, turns[0].Usage)
+		assert.Equal(t, "Let me calculate that.", turns[0].Text())
+		assert.Equal(t, event.StopEnd, turns[1].StopReason)
+		assert.Equal(t, event.Usage{InputTokens: 20, OutputTokens: 4}, turns[1].Usage)
+		assert.Equal(t, "The result is 56088.", turns[1].Text())
+	}
+	toolEndIndex := outputIndex(outputs, event.ToolEnd{})
+	messageEndIndex := outputIndex(outputs, event.AssistantMessageEnd{})
+	turnEndIndex := outputIndex(outputs, event.TurnEnd{})
+	assert.NotEqual(t, -1, toolEndIndex)
+	assert.NotEqual(t, -1, messageEndIndex)
+	assert.NotEqual(t, -1, turnEndIndex)
+	assert.Less(t, toolEndIndex, messageEndIndex)
+	assert.Less(t, messageEndIndex, turnEndIndex)
 	assert.Equal(t, 2, provider.CallCount())
 
 	messages, err := sess.Messages(ctx)
@@ -95,51 +116,90 @@ func TestLLMAgentExecutesCalculateTool(t *testing.T) {
 	}
 }
 
-func TestLLMAgentAssistantMessageEndOptIn(t *testing.T) {
+func TestLLMAgentTurnHooksWrapOneModelCall(t *testing.T) {
 	provider := dummyprovider.NewProvider(
-		dummyprovider.AssistantResponse(
-			[]content.Part{
-				dummyprovider.Text("Let me calculate that."),
-				dummyprovider.ToolUse("calc-1", "calculate", json.RawMessage(`{"expression":"123 * 456"}`)),
-			},
-			dummyprovider.WithStopReason(model.StopToolUse),
-			dummyprovider.WithResponseUsage(model.Usage{InputTokens: 10, OutputTokens: 3}),
+		dummyprovider.ToolUseResponse(
+			"calc-1",
+			"calculate",
+			json.RawMessage(`{"expression":"1 + 1"}`),
+			dummyprovider.WithResponseUsage(model.Usage{InputTokens: 10, OutputTokens: 2}),
 		),
 		dummyprovider.TextResponse(
-			"The result is 56088.",
-			dummyprovider.WithResponseUsage(model.Usage{InputTokens: 20, OutputTokens: 4}),
+			"done",
+			dummyprovider.WithResponseUsage(model.Usage{InputTokens: 20, OutputTokens: 3}),
 		),
 	)
+	capture := &turnLifecycleCapture{}
 	agent, err := blades.NewAgent(
 		"calculator",
 		blades.WithModel(provider),
 		blades.WithTools(testtools.NewCalculateTool()),
-		blades.WithAssistantMessageEnd(true),
+		blades.WithHooks(capture),
 	)
 	assert.NoError(t, err)
 
-	inputs := make(chan event.Input, 1)
-	inputs <- event.NewPrompt("What is 123 * 456?")
+	outputs, err := collectAllAgentOutputs(context.Background(), agent, promptInputs("calculate"))
+	assert.NoError(t, err)
+	assert.Len(t, turnEnds(outputs), 2)
 
-	outputs, err := collectAgentOutputs(context.Background(), agent, inputs)
+	starts, ends, toolTurns := capture.Snapshot()
+	if assert.Len(t, starts, 2) {
+		assert.Equal(t, 1, starts[0].turn)
+		assert.IsType(t, event.Prompt{}, starts[0].input)
+		assert.Equal(t, 2, starts[1].turn)
+		assert.Nil(t, starts[1].input)
+	}
+	if assert.Len(t, ends, 2) {
+		assert.Equal(t, 1, ends[0].turn)
+		assert.Equal(t, model.StopToolUse, ends[0].stopReason)
+		assert.Equal(t, model.Usage{InputTokens: 10, OutputTokens: 2}, ends[0].usage)
+		assert.Equal(t, 2, ends[1].turn)
+		assert.Equal(t, model.StopEnd, ends[1].stopReason)
+		assert.Equal(t, model.Usage{InputTokens: 20, OutputTokens: 3}, ends[1].usage)
+	}
+	assert.Equal(t, []int{1}, toolTurns)
+}
+
+func TestLLMAgentProviderFailureHasNoAssistantMessageEnd(t *testing.T) {
+	agent, err := blades.NewAgent("assistant", blades.WithModel(dummyprovider.NewProvider()))
 	assert.NoError(t, err)
 
-	messageEnds := assistantMessageEnds(outputs)
-	if assert.Len(t, messageEnds, 2) {
-		assert.Equal(t, event.StopToolUse, messageEnds[0].StopReason)
-		assert.Equal(t, int64(10), messageEnds[0].Usage.InputTokens)
-		assert.Equal(t, int64(3), messageEnds[0].Usage.OutputTokens)
-		assert.Equal(t, "Let me calculate that.", messageEnds[0].Text())
-		assert.Equal(t, event.StopEnd, messageEnds[1].StopReason)
-		assert.Equal(t, int64(20), messageEnds[1].Usage.InputTokens)
-		assert.Equal(t, int64(4), messageEnds[1].Usage.OutputTokens)
-		assert.Equal(t, "The result is 56088.", messageEnds[1].Text())
+	outputs, err := collectAllAgentOutputs(context.Background(), agent, promptInputs("hello"))
+	assert.NoError(t, err)
+	assert.Empty(t, assistantMessageEnds(outputs))
+
+	turns := turnEnds(outputs)
+	if assert.Len(t, turns, 1) {
+		assert.ErrorIs(t, turns[0].Err, dummyprovider.ErrNoResponses)
 	}
-	messageEndIndex := outputIndex(outputs, event.AssistantMessageEnd{})
-	toolStartIndex := outputIndex(outputs, event.ToolStart{})
-	assert.NotEqual(t, -1, messageEndIndex)
-	assert.NotEqual(t, -1, toolStartIndex)
-	assert.Less(t, messageEndIndex, toolStartIndex)
+	assert.True(t, hasRuntimeError(outputs, dummyprovider.ErrNoResponses))
+}
+
+func TestLLMAgentAfterModelFailurePreservesAssistantMessageEnd(t *testing.T) {
+	want := errors.New("after model failed")
+	provider := dummyprovider.NewProvider(dummyprovider.TextResponse(
+		"completed",
+		dummyprovider.WithResponseUsage(model.Usage{InputTokens: 4, OutputTokens: 2}),
+	))
+	agent, err := blades.NewAgent(
+		"assistant",
+		blades.WithModel(provider),
+		blades.WithHooks(afterModelErrorHook{err: want}),
+	)
+	assert.NoError(t, err)
+
+	outputs, err := collectAllAgentOutputs(context.Background(), agent, promptInputs("hello"))
+	assert.NoError(t, err)
+	messageEnds := assistantMessageEnds(outputs)
+	if assert.Len(t, messageEnds, 1) {
+		assert.Equal(t, "completed", messageEnds[0].Text())
+		assert.Equal(t, event.Usage{InputTokens: 4, OutputTokens: 2}, messageEnds[0].Usage)
+	}
+	turns := turnEnds(outputs)
+	if assert.Len(t, turns, 1) {
+		assert.ErrorIs(t, turns[0].Err, want)
+	}
+	assert.True(t, hasRuntimeError(outputs, want))
 }
 
 func TestLLMAgentResolvesToolUseNotListedUpfront(t *testing.T) {
@@ -158,7 +218,11 @@ func TestLLMAgentResolvesToolUseNotListedUpfront(t *testing.T) {
 			staticTextTool{name: "tool_search", description: "Search deferred tools", result: "found"},
 		},
 		byName: map[string]tools.Tool{
-			deferredName: staticTextTool{name: deferredName, description: "Get current time", result: "2026-06-23T12:00:00+08:00"},
+			deferredName: staticTextTool{
+				name:        deferredName,
+				description: "Get current time",
+				result:      "2026-06-23T12:00:00+08:00",
+			},
 		},
 	}
 	agent, err := blades.NewAgent(
@@ -360,9 +424,33 @@ func TestLLMAgentInjectsRunningAgentIntoRuntimeExtensions(t *testing.T) {
 	assert.True(t, ok)
 	assert.NoError(t, turnEnd.Err)
 
-	assertRunningAgentSnapshot(t, promptCapture.Snapshot(), "assistant", "main agent", false, "", "assistant")
-	assertRunningAgentSnapshot(t, hookCapture.Snapshot(), "assistant", "main agent", false, "", "assistant")
-	assertRunningAgentSnapshot(t, toolCapture.Snapshot(), "assistant", "main agent", false, "", "assistant")
+	assertRunningAgentSnapshot(
+		t,
+		promptCapture.Snapshot(),
+		"assistant",
+		"main agent",
+		false,
+		"",
+		"assistant",
+	)
+	assertRunningAgentSnapshot(
+		t,
+		hookCapture.Snapshot(),
+		"assistant",
+		"main agent",
+		false,
+		"",
+		"assistant",
+	)
+	assertRunningAgentSnapshot(
+		t,
+		toolCapture.Snapshot(),
+		"assistant",
+		"main agent",
+		false,
+		"",
+		"assistant",
+	)
 	assert.NoError(t, forkErr)
 	assert.Equal(t, "assistant-fork", forkName)
 	assert.Equal(t, "forked", forkDesc)
@@ -404,7 +492,40 @@ func TestAgentToolSetsParentRunningAgentForSubAgent(t *testing.T) {
 	assert.True(t, ok)
 	assert.NoError(t, turnEnd.Err)
 	assert.Equal(t, "main final", textFromParts(turnEnd.Parts))
-	assertRunningAgentSnapshot(t, subCapture.Snapshot(), "delegate", "sub agent", true, "main", "main")
+	assertRunningAgentSnapshot(
+		t,
+		subCapture.Snapshot(),
+		"delegate",
+		"sub agent",
+		true,
+		"main",
+		"main",
+	)
+}
+
+func TestAgentToolReturnsOnlyFinalTurnParts(t *testing.T) {
+	subProvider := dummyprovider.NewProvider(
+		dummyprovider.AssistantResponse(
+			[]content.Part{
+				content.Text{Text: "intermediate"},
+				dummyprovider.ToolUse("calc-1", "calculate", json.RawMessage(`{"expression":"1 + 1"}`)),
+			},
+			dummyprovider.WithStopReason(model.StopToolUse),
+		),
+		dummyprovider.TextResponse("final"),
+	)
+	sub, err := blades.NewAgent(
+		"delegate",
+		blades.WithModel(subProvider),
+		blades.WithTools(testtools.NewCalculateTool()),
+	)
+	assert.NoError(t, err)
+
+	result, err := blades.NewAgentTool(sub).Handle(context.Background(), json.RawMessage(`"calculate"`))
+	assert.NoError(t, err)
+	if assert.NotNil(t, result) {
+		assert.Equal(t, "final", textFromParts(result.Parts))
+	}
 }
 
 func TestRunningAgentFromContextMissing(t *testing.T) {
@@ -698,6 +819,13 @@ func TestLLMAgentParallelToolEndsInCompletionOrder(t *testing.T) {
 		"end:fast",
 		"end:slow",
 	}, toolLifecycle(outputs))
+	messageEndIndex := outputIndex(outputs, event.AssistantMessageEnd{})
+	assert.NotEqual(t, -1, messageEndIndex)
+	for i, output := range outputs {
+		if _, ok := output.(event.ToolEnd); ok {
+			assert.Less(t, i, messageEndIndex)
+		}
+	}
 
 	messages, err := sess.Messages(ctx)
 	assert.NoError(t, err)
@@ -790,7 +918,7 @@ func TestLLMAgentQueuesPromptArrivingDuringActiveTurn(t *testing.T) {
 	}
 }
 
-func TestLLMAgentSteerContinuesCurrentTurn(t *testing.T) {
+func TestLLMAgentSteerStartsNextTurn(t *testing.T) {
 	provider := dummyprovider.NewProvider(
 		dummyprovider.TextResponse("draft"),
 		dummyprovider.TextResponse("final"),
@@ -809,9 +937,11 @@ func TestLLMAgentSteerContinuesCurrentTurn(t *testing.T) {
 	assert.NoError(t, err)
 
 	turns := turnEnds(outputs)
-	if assert.Len(t, turns, 1) {
+	if assert.Len(t, turns, 2) {
+		assert.Equal(t, "draft", turns[0].Text())
 		assert.Equal(t, event.StopEnd, turns[0].StopReason)
-		assert.Equal(t, "final", textFromParts(turns[0].Parts))
+		assert.Equal(t, "final", turns[1].Text())
+		assert.Equal(t, event.StopEnd, turns[1].StopReason)
 	}
 	assert.Equal(t, 2, provider.CallCount())
 
@@ -825,7 +955,7 @@ func TestLLMAgentSteerContinuesCurrentTurn(t *testing.T) {
 	}
 }
 
-func TestLLMAgentSteerDuringToolWaveContinuesCurrentTurn(t *testing.T) {
+func TestLLMAgentSteerDuringToolWaveStartsNextTurn(t *testing.T) {
 	releaseTool := make(chan struct{})
 	provider := dummyprovider.NewProvider(
 		dummyprovider.AssistantResponse(
@@ -849,15 +979,23 @@ func TestLLMAgentSteerDuringToolWaveContinuesCurrentTurn(t *testing.T) {
 	inputs := make(chan event.Input, 2)
 	inputs <- event.NewPrompt("start")
 
-	outputs, err := collectAllAgentOutputsWithToolStartInput(ctx, agent, inputs, "block-1", event.NewSteer("revise"), func() {
-		close(releaseTool)
-	})
+	outputs, err := collectAllAgentOutputsWithToolStartInput(
+		ctx,
+		agent,
+		inputs,
+		"block-1",
+		event.NewSteer("revise"),
+		func() {
+			close(releaseTool)
+		},
+	)
 	assert.NoError(t, err)
 
 	turns := turnEnds(outputs)
-	if assert.Len(t, turns, 1) {
-		assert.Equal(t, event.StopEnd, turns[0].StopReason)
-		assert.Equal(t, "final", textFromParts(turns[0].Parts))
+	if assert.Len(t, turns, 2) {
+		assert.Equal(t, event.StopToolUse, turns[0].StopReason)
+		assert.Equal(t, event.StopEnd, turns[1].StopReason)
+		assert.Equal(t, "final", turns[1].Text())
 	}
 	assert.Equal(t, 2, provider.CallCount())
 
@@ -912,7 +1050,7 @@ func TestLLMAgentMultipleSteersDuringToolWavePreserveContentParts(t *testing.T) 
 		if !ok || toolStart.ID != "block-1" || sent {
 			continue
 		}
-		// Queue two steers at the same step boundary; they merge into the trailing
+		// Queue two steers at the same turn boundary; they merge into the trailing
 		// tool message with separate parts.
 		inputs <- event.NewSteer("revise once")
 		inputs <- event.NewSteer(" and twice")
@@ -922,8 +1060,9 @@ func TestLLMAgentMultipleSteersDuringToolWavePreserveContentParts(t *testing.T) 
 	}
 
 	turns := turnEnds(collected)
-	if assert.Len(t, turns, 1) {
-		assert.Equal(t, "final", textFromParts(turns[0].Parts))
+	if assert.Len(t, turns, 2) {
+		assert.Equal(t, event.StopToolUse, turns[0].StopReason)
+		assert.Equal(t, "final", turns[1].Text())
 	}
 
 	messages, err := sess.Messages(ctx)
@@ -938,7 +1077,7 @@ func TestLLMAgentMultipleSteersDuringToolWavePreserveContentParts(t *testing.T) 
 	}
 }
 
-func TestLLMAgentPromptDuringToolWaveStartsNextTurn(t *testing.T) {
+func TestLLMAgentPromptDuringToolWaveWaitsForNextInteraction(t *testing.T) {
 	releaseTool := make(chan struct{})
 	provider := dummyprovider.NewProvider(
 		dummyprovider.AssistantResponse(
@@ -963,17 +1102,25 @@ func TestLLMAgentPromptDuringToolWaveStartsNextTurn(t *testing.T) {
 	inputs := make(chan event.Input, 2)
 	inputs <- event.NewPrompt("start")
 
-	outputs, err := collectAllAgentOutputsWithToolStartInput(ctx, agent, inputs, "block-1", event.NewPrompt("next"), func() {
-		close(releaseTool)
-	})
+	outputs, err := collectAllAgentOutputsWithToolStartInput(
+		ctx,
+		agent,
+		inputs,
+		"block-1",
+		event.NewPrompt("next"),
+		func() {
+			close(releaseTool)
+		},
+	)
 	assert.NoError(t, err)
 
 	turns := turnEnds(outputs)
-	if assert.Len(t, turns, 2) {
-		assert.Equal(t, event.StopEnd, turns[0].StopReason)
-		assert.Equal(t, "first final", textFromParts(turns[0].Parts))
+	if assert.Len(t, turns, 3) {
+		assert.Equal(t, event.StopToolUse, turns[0].StopReason)
 		assert.Equal(t, event.StopEnd, turns[1].StopReason)
-		assert.Equal(t, "second final", textFromParts(turns[1].Parts))
+		assert.Equal(t, "first final", turns[1].Text())
+		assert.Equal(t, event.StopEnd, turns[2].StopReason)
+		assert.Equal(t, "second final", turns[2].Text())
 	}
 	assert.Equal(t, 3, provider.CallCount())
 
@@ -1020,22 +1167,6 @@ func TestLLMAgentAbortOnlyEndsCurrentTurn(t *testing.T) {
 	}
 }
 
-func collectAgentOutputs(ctx context.Context, agent blades.Agent, inputs <-chan event.Input) ([]event.Output, error) {
-	outputs, err := agent.Run(ctx, inputs)
-	if err != nil {
-		return nil, err
-	}
-
-	var collected []event.Output
-	for output := range outputs {
-		collected = append(collected, output)
-		if _, ok := output.(event.TurnEnd); ok {
-			return collected, nil
-		}
-	}
-	return collected, nil
-}
-
 func promptInputs(text string) <-chan event.Input {
 	inputs := make(chan event.Input, 1)
 	inputs <- event.NewPrompt(text)
@@ -1043,7 +1174,11 @@ func promptInputs(text string) <-chan event.Input {
 	return inputs
 }
 
-func collectAllAgentOutputs(ctx context.Context, agent blades.Agent, inputs <-chan event.Input) ([]event.Output, error) {
+func collectAllAgentOutputs(
+	ctx context.Context,
+	agent blades.Agent,
+	inputs <-chan event.Input,
+) ([]event.Output, error) {
 	outputs, err := agent.Run(ctx, inputs)
 	if err != nil {
 		return nil, err
@@ -1056,7 +1191,14 @@ func collectAllAgentOutputs(ctx context.Context, agent blades.Agent, inputs <-ch
 	return collected, nil
 }
 
-func collectAllAgentOutputsWithToolStartInput(ctx context.Context, agent blades.Agent, inputs chan event.Input, toolID string, in event.Input, release func()) ([]event.Output, error) {
+func collectAllAgentOutputsWithToolStartInput(
+	ctx context.Context,
+	agent blades.Agent,
+	inputs chan event.Input,
+	toolID string,
+	in event.Input,
+	release func(),
+) ([]event.Output, error) {
 	outputs, err := agent.Run(ctx, inputs)
 	if err != nil {
 		return nil, err
@@ -1136,6 +1278,15 @@ func assistantMessageEnds(outputs []event.Output) []event.AssistantMessageEnd {
 	return messageEnds
 }
 
+func hasRuntimeError(outputs []event.Output, want error) bool {
+	for _, output := range outputs {
+		if runtimeErr, ok := output.(event.Error); ok && errors.Is(runtimeErr.Err, want) {
+			return true
+		}
+	}
+	return false
+}
+
 func outputIndex(outputs []event.Output, target event.Output) int {
 	for i, output := range outputs {
 		if reflect.TypeOf(output) == reflect.TypeOf(target) {
@@ -1211,6 +1362,66 @@ func (h *rewriteToolResultHook) AfterTool(_ context.Context, _ *hook.ToolCall, r
 	return nil
 }
 
+type turnStartRecord struct {
+	turn  int
+	input event.Input
+}
+
+type turnEndRecord struct {
+	turn       int
+	stopReason model.StopReason
+	usage      model.Usage
+}
+
+type turnLifecycleCapture struct {
+	hook.Noop
+	mu        sync.Mutex
+	starts    []turnStartRecord
+	ends      []turnEndRecord
+	toolTurns []int
+}
+
+func (h *turnLifecycleCapture) BeforeTurn(_ context.Context, turn *hook.Turn) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.starts = append(h.starts, turnStartRecord{turn: turn.Turn, input: turn.Input})
+	return nil
+}
+
+func (h *turnLifecycleCapture) AfterTurn(_ context.Context, turn *hook.Turn, summary *hook.TurnSummary, _ error) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	record := turnEndRecord{
+		turn:       turn.Turn,
+		stopReason: summary.StopReason,
+		usage:      *summary.Usage,
+	}
+	h.ends = append(h.ends, record)
+	return nil
+}
+
+func (h *turnLifecycleCapture) BeforeTool(_ context.Context, call *hook.ToolCall) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.toolTurns = append(h.toolTurns, call.Turn)
+	return nil
+}
+
+func (h *turnLifecycleCapture) Snapshot() ([]turnStartRecord, []turnEndRecord, []int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return slices.Clone(h.starts), slices.Clone(h.ends), slices.Clone(h.toolTurns)
+}
+
+type afterModelErrorHook struct {
+	hook.Noop
+	err error
+}
+
+func (h afterModelErrorHook) AfterModel(context.Context, *model.Request, *model.Response, error) error {
+	return h.err
+}
+
 type runningAgentSnapshot struct {
 	ok          bool
 	name        string
@@ -1255,7 +1466,15 @@ func snapshotRunningAgent(ctx context.Context) runningAgentSnapshot {
 	return snapshot
 }
 
-func assertRunningAgentSnapshot(t *testing.T, snapshot runningAgentSnapshot, name, description string, hasParent bool, parentName, rootName string) {
+func assertRunningAgentSnapshot(
+	t *testing.T,
+	snapshot runningAgentSnapshot,
+	name string,
+	description string,
+	hasParent bool,
+	parentName string,
+	rootName string,
+) {
 	t.Helper()
 	assert.True(t, snapshot.ok)
 	assert.Equal(t, name, snapshot.name)

--- a/tests/agent/llm_agent_test.go
+++ b/tests/agent/llm_agent_test.go
@@ -175,7 +175,7 @@ func TestLLMAgentProviderFailureHasNoAssistantMessageEnd(t *testing.T) {
 	assert.True(t, hasRuntimeError(outputs, dummyprovider.ErrNoResponses))
 }
 
-func TestLLMAgentAfterModelFailurePreservesAssistantMessageEnd(t *testing.T) {
+func TestLLMAgentAfterModelFailureDiscardsResponse(t *testing.T) {
 	want := errors.New("after model failed")
 	provider := dummyprovider.NewProvider(dummyprovider.TextResponse(
 		"completed",
@@ -190,14 +190,12 @@ func TestLLMAgentAfterModelFailurePreservesAssistantMessageEnd(t *testing.T) {
 
 	outputs, err := collectAllAgentOutputs(context.Background(), agent, promptInputs("hello"))
 	assert.NoError(t, err)
-	messageEnds := assistantMessageEnds(outputs)
-	if assert.Len(t, messageEnds, 1) {
-		assert.Equal(t, "completed", messageEnds[0].Text())
-		assert.Equal(t, event.Usage{InputTokens: 4, OutputTokens: 2}, messageEnds[0].Usage)
-	}
+	assert.Empty(t, assistantMessageEnds(outputs))
 	turns := turnEnds(outputs)
 	if assert.Len(t, turns, 1) {
 		assert.ErrorIs(t, turns[0].Err, want)
+		assert.Empty(t, turns[0].Parts)
+		assert.Equal(t, event.Usage{}, turns[0].Usage)
 	}
 	assert.True(t, hasRuntimeError(outputs, want))
 }

--- a/tool.go
+++ b/tool.go
@@ -3,6 +3,7 @@ package blades
 import (
 	"context"
 	"encoding/json"
+	"slices"
 
 	"github.com/go-kratos/blades/content"
 	"github.com/go-kratos/blades/event"
@@ -49,7 +50,7 @@ func (t *agentTool) Handle(ctx context.Context, input json.RawMessage) (*tools.R
 	for out := range output {
 		switch v := out.(type) {
 		case event.TurnEnd:
-			parts = append(parts, v.Parts...)
+			parts = slices.Clone(v.Parts)
 		case event.Error:
 			return nil, v.Err
 		}


### PR DESCRIPTION
## Problem

An agent turn currently spans one or more model calls, which makes turn hooks,
usage, and terminal events interaction-scoped instead of directly traceable to
the model call that produced them.

## Changes

- End each turn after one model call and its resulting tool wave.
- Emit `AssistantMessageEnd` for every model response accepted by `AfterModel`.
- Discard the response, usage, and message-end event when `AfterModel` fails.
- Order tool turns as `ToolEnd` -> `AssistantMessageEnd` -> `TurnEnd`.
- Keep usage and stop reasons local to the corresponding model call.
- Start steering continuations as new turns while queueing prompts for the next
  interaction.
- Update runners, agent tools, flow bridging, documentation, and lifecycle
  tests for multi-turn interactions.

## Compatibility

- `WithAssistantMessageEnd` is removed; `AssistantMessageEnd` is mandatory for
  responses accepted by `AfterModel`.
- Consumers that treated `TurnEnd` as the end of a complete interaction must
  now wait for `Done` or select the last `TurnEnd`.
- Turn hooks now run once per model call rather than once per interaction.

## Validation

- `make test`
